### PR TITLE
Remove hardcoded timeouts. Add a pause into the Docker Env test.

### DIFF
--- a/test/ui/commands/login.js
+++ b/test/ui/commands/login.js
@@ -5,7 +5,7 @@ exports.command = function (url) {
     this
         .resizeWindow(1280,1024)
         .url(url)
-        .waitForElementVisible('button[type=submit]', 30000)
+        .waitForElementVisible('button[type=submit]')
         .setValue('#user', 'user')
         .setValue('#password', 'pwd')
         .click('button[type=submit]')

--- a/test/ui/nightwatch.json
+++ b/test/ui/nightwatch.json
@@ -33,7 +33,7 @@
             },
             "globals" : {
                 "studio_url" : "http://localhost:8080/studio",
-                "waitForConditionTimeout" : 1000,
+                "waitForConditionTimeout" : 5000,
                 "waitForConditionPollInterval" : 100
             }
         },

--- a/test/ui/specs/dependencies.js
+++ b/test/ui/specs/dependencies.js
@@ -7,7 +7,7 @@ module.exports = {
             .login()
             .freshWorkflow()
             .createTask()
-            .waitForElementVisible('.dependency-source-endpoint', 5000)
+            .waitForElementVisible('.dependency-source-endpoint')
             .moveToElement('.dependency-source-endpoint', 0, 15)
             .mouseButtonDown(0)
             .moveToElement('#workflow-designer', 200, 200)

--- a/test/ui/specs/forkExecutionEnvironment.js
+++ b/test/ui/specs/forkExecutionEnvironment.js
@@ -1,40 +1,38 @@
 module.exports = {
-    // Set global timeout to 5 seconds. This will be applied to each wait for which does not
-    // specify a timeout
-    waitForConditionTimeout: 5000,
     "Find Fork Execution Environment setting": function (browser) {
         browser
             .login() // Login into the interface
             .closeNotification() // Close all notifications
             .freshWorkflow() // Create a new workflow
-            .waitForElementVisible('#accordion-properties', 5000) // Wait for the sidebar to be visible
+            .waitForElementVisible('#accordion-properties') // Wait for the sidebar to be visible
             .assert.elementNotPresent("#simple-form")
             .createTask() // Add a task to the workflow
             .click(".task") // Select the task -- that will show a new sidebar
             .useXpath() // every selector now must be xpath
-            .waitForElementVisible('//*[@id=\"Fork Environment\"]', 5000) // Check for the Fork Environment tab
+            .waitForElementVisible('//*[@id=\"Fork Environment\"]') // Check for the Fork Environment tab
             .click('//*[@id=\"Fork Environment\"]') // Click on the Fork Environment tab
             // Wait for the For Execution Environment select to be visible
-            .waitForElementVisible('//select[@name=\"Fork Execution Environment\"]', 5000)
+            .waitForElementVisible('//select[@name=\"Fork Execution Environment\"]')
             .useCss() // we're back to CSS now
             .end(); // That's it done
     },
-    "Test that ocker Execution Environment setting is inserted on selection": function (browser) {
+    "Test that Docker Execution Environment setting is inserted on selection": function (browser) {
         browser
             .login() // Login into the interface
             .closeNotification() // Close all notifications
             .freshWorkflow() // Create a new workflow
-            .waitForElementVisible('#accordion-properties', 5000) // Wait for the sidebar to be visible
+            .waitForElementVisible('#accordion-properties') // Wait for the sidebar to be visible
             .assert.elementNotPresent("#simple-form")
             .createTask() // Add a task to the workflow
             .click(".task") // Select the task -- that will show a new sidebar
             .useXpath() // every selector now must be xpath
-            .waitForElementVisible('//*[@id=\"Fork Environment\"]', 5000) // Check for the Fork Environment tab
+            .waitForElementVisible('//*[@id=\"Fork Environment\"]') // Check for the Fork Environment tab
             .click('//*[@id=\"Fork Environment\"]') // Click on the Fork Environment tab
             // Wait for the For Execution Environment select to be visible
-            .waitForElementVisible('//select[@name=\"Fork Execution Environment\"]', 5000)
+            .waitForElementVisible('//select[@name=\"Fork Execution Environment\"]')
             // Click in the Fork Execution Enviuronment selector and select 2 (Docker)
             .click('//select[@name=\"Fork Execution Environment\"]/option[2]')
+            .pause(2000)
             .getValue('//input[@name=\"Java Home\"]' ,
             function (result) {
                 this.assert.equal(typeof result, "object");


### PR DESCRIPTION
Remove hardcoded timeouts. Add a pause into the Docker Env test.

All hardcoded timeouts are removed. So that every waitFor takes the globally configured timeout.
The Docker Env tests fail on the server but run locally. Furthermore they run locally against the current trydev. Whereas they fail on the server against trydev. The pause is intended to fix this behavior.