### PR TITLE
Prevent the Studio test run into an infinite loop of failures.

### DIFF
--- a/test/ui/commands/freshWorkflow.js
+++ b/test/ui/commands/freshWorkflow.js
@@ -4,16 +4,17 @@
 exports.command = function () {
     var browser = this
 
-    var deleteWorkflows = function () {
+    var deleteWorkflows = function (iteration, amount) {
         // isVisible will cause a test failure if element cannot be found, fallback to Selenium method
         browser.element("css selector", ".btn-remove", function (result) {
-            if (result.status === 0) {
+            console.log("Remove Workflows, iteration: "+iteration+", max repetitions: "+amount)
+            if (result.status === 0 && iteration < amount) {
                 browser.click('.btn-remove')
-                deleteWorkflows();
+                deleteWorkflows(iteration +1, amount);
             }
         })
     }
-    deleteWorkflows();
+    deleteWorkflows(0, browser.globals.numberOfTries);
 
     browser
         .click('.create-workflow-button')

--- a/test/ui/commands/hideMenu.js
+++ b/test/ui/commands/hideMenu.js
@@ -5,16 +5,17 @@
 exports.command = function () {
     var browser = this
 
-    var hideMenu = function () {
+    var hideMenu = function (iteration, amount) {
         // isVisible will cause a test failure if element cannot be found, fallback to Selenium method
         browser.element("css selector", "div.navbar-collapse.collapsed", function (result) {
-            if (result.status === 0) {
+            console.log("Hide menu, iteration: "+iteration+" max repetitions: "+amount)
+            if (result.status === 0 && iteration < amount) {
                 browser.click('.navbar-toggle')
-                hideMenu()
+                hideMenu(iteration++, amount)
             }
         })
     }
-    hideMenu();
+    hideMenu(0, browser.globals.numberOfTries);
 
     return this;
 };

--- a/test/ui/commands/hideMenu.js
+++ b/test/ui/commands/hideMenu.js
@@ -11,7 +11,7 @@ exports.command = function () {
             console.log("Hide menu, iteration: "+iteration+" max repetitions: "+amount)
             if (result.status === 0 && iteration < amount) {
                 browser.click('.navbar-toggle')
-                hideMenu(iteration++, amount)
+                hideMenu(iteration +1, amount)
             }
         })
     }

--- a/test/ui/commands/showMenu.js
+++ b/test/ui/commands/showMenu.js
@@ -5,16 +5,17 @@
 exports.command = function () {
     var browser = this
 
-    var showMenu = function () {
+    var showMenu = function (iteration, amount) {
         // isVisible will cause a test failure if element cannot be found, fallback to Selenium method
         browser.element("css selector", ".navbar-collapse.in", function (result) {
-            if (result.status != 0) {
+            console.log("Show menu, iteration: "+iteration+" max repetitions: "+amount)
+            if (result.status != 0 && iteration < amount ) {
                 browser.click('.navbar-toggle').pause(2000)
-                showMenu()
+                showMenu(iteration++, amount)
             }
         })
     }
-    showMenu();
+    showMenu(0, browser.globals.numberOfTries);
 
     return this;
 };

--- a/test/ui/commands/showMenu.js
+++ b/test/ui/commands/showMenu.js
@@ -11,7 +11,7 @@ exports.command = function () {
             console.log("Show menu, iteration: "+iteration+" max repetitions: "+amount)
             if (result.status != 0 && iteration < amount ) {
                 browser.click('.navbar-toggle').pause(2000)
-                showMenu(iteration++, amount)
+                showMenu(iteration +1, amount)
             }
         })
     }

--- a/test/ui/nightwatch.json
+++ b/test/ui/nightwatch.json
@@ -34,14 +34,16 @@
             "globals" : {
                 "studio_url" : "http://localhost:8080/studio",
                 "waitForConditionTimeout" : 5000,
+                "numberOfTries" : 50,
                 "waitForConditionPollInterval" : 100
             }
         },
         "trydev" : {
             "globals" : {
                 "studio_url" : "http://trydev.activeeon.com/studio",
-                "waitForConditionTimeout" : 5000,
-                "waitForConditionPollInterval" : 100
+                "waitForConditionTimeout" : 30000,
+                "numberOfTries" : 50,
+                "waitForConditionPollInterval" : 500
             }
         }
     }


### PR DESCRIPTION
Prevent the Studio test run into an infinite loop of failures.

The selenium tests have some parts, which retry in an infinite loop. That can and did let the test run into an infinite loop, blocking jenkins and flooding the file system with error reports. To prevent that from happening again, a maximum number of tries is introduced.