### PR TITLE
Wait for moving element to stop to perform a click.

### DIFF
--- a/test/ui/specs/forkExecutionEnvironment.js
+++ b/test/ui/specs/forkExecutionEnvironment.js
@@ -27,6 +27,7 @@ module.exports = {
             .click(".task") // Select the task -- that will show a new sidebar
             .useXpath() // every selector now must be xpath
             .waitForElementVisible('//*[@id=\"Fork Environment\"]') // Check for the Fork Environment tab
+            .pause(1000)// The click logic runs while the interface is still moving, so wait
             .click('//*[@id=\"Fork Environment\"]') // Click on the Fork Environment tab
             .pause(browser.globals.waitForConditionTimeout)
             // Wait for the For Execution Environment select to be visible


### PR DESCRIPTION
Wait for moving element to stop to perform a click.

The Fork Environment tab seems to move, while the click is performed. The assumption comes from the fact that the selenium test fails with element not clickable but not reproducible in a virtual machine (much slower one).