### PR TITLE
Move to Element before click.

### DIFF
--- a/test/ui/specs/forkExecutionEnvironment.js
+++ b/test/ui/specs/forkExecutionEnvironment.js
@@ -27,6 +27,7 @@ module.exports = {
             .click(".task") // Select the task -- that will show a new sidebar
             .useXpath() // every selector now must be xpath
             .waitForElementVisible('//*[@id=\"Fork Environment\"]') // Check for the Fork Environment tab
+            .moveToElement('//*[@id=\"Fork Environment\"]', 10, 10)
             .click('//*[@id=\"Fork Environment\"]') // Click on the Fork Environment tab
             .pause(browser.globals.waitForConditionTimeout)
             // Wait for the For Execution Environment select to be visible


### PR DESCRIPTION
Move to Element before click.

That the forefox driver behavior changed, so an element must be visible before it is clickable. The curser is moved (and the menu is scrolled) to the element before it is clicked.