### PR TITLE
Fix failing "Pull out a dependency" Studio test

### DIFF
--- a/test/ui/commands/checkExport.js
+++ b/test/ui/commands/checkExport.js
@@ -15,7 +15,7 @@ exports.command = function (xpathCheck) {
                 var xpath = require('xpath')
                     , dom = require('xmldom').DOMParser
 
-                var select = xpath.useNamespaces({"p": "urn:proactive:jobdescriptor:3.3"});
+                var select = xpath.useNamespaces({"p": "urn:proactive:jobdescriptor:3.4"});
 
                 var jobXmlDocument = new dom().parseFromString(jobXml)
 


### PR DESCRIPTION
The studio test parses the xml in the export window. The parsing method looks for the jobdescriptor 3.3. We updated the jobdescriptor to 3.4, so this test needs to be adjusted as well.