### PR TITLE
Imported Workflows need to be converted.

### DIFF
--- a/app/scripts/proactive/model/Job.js
+++ b/app/scripts/proactive/model/Job.js
@@ -95,6 +95,7 @@ define(
         },
         populate: function (obj, merging) {
             this.populateSchema(obj, merging);
+            this.convertCancelJobOnErrorToOnTaskError(obj);
             var that = this;
             if (obj.taskFlow && obj.taskFlow.task) {
 
@@ -120,7 +121,7 @@ define(
                         taskModel.set({'Execute': new ScriptExecutable()});
                         taskModel.set({Type: "ScriptExecutable"});
                     }
-
+                    taskModel.convertCancelJobOnErrorToOnTaskError(task);
                     taskModel.populateSchema(task);
                     taskModel.populateSimpleForm();
 

--- a/app/scripts/proactive/model/SchemaModel.js
+++ b/app/scripts/proactive/model/SchemaModel.js
@@ -42,12 +42,10 @@ define(
             }
         },convertCancelJobOnErrorToOnTaskError: function (obj) {
             if (obj["@attributes"]['cancelOnJobError'] && obj["@attributes"]['cancelOnJobError']  == "true") {
-                //var placeholderName = this.schema['On Task Error Policy'].fieldAttrs.placeholder;
                 this.set("On Task Error Policy", "cancelJob")
             }
         },
         populateSchema: function (obj, merging) {
-//            console.log("Populating", obj, this.schema)
             var that = this;
 
             for (var prop in this.schema) {

--- a/app/scripts/proactive/model/SchemaModel.js
+++ b/app/scripts/proactive/model/SchemaModel.js
@@ -40,6 +40,11 @@ define(
             } else {
                 return this.getValue(listSchema.fieldAttrs.itemplaceholder, listElemObj);
             }
+        },convertCancelJobOnErrorToOnTaskError: function (obj) {
+            if (obj["@attributes"]['cancelOnJobError'] && obj["@attributes"]['cancelOnJobError']  == "true") {
+                //var placeholderName = this.schema['On Task Error Policy'].fieldAttrs.placeholder;
+                this.set("On Task Error Policy", "cancelJob")
+            }
         },
         populateSchema: function (obj, merging) {
 //            console.log("Populating", obj, this.schema)


### PR DESCRIPTION
Imported Workflows need to be converted to not change their behavior.
Workflows which had CancelJobOnError='true' where converted into onTaskError='continueJobExecution'. That changed the error behavior of tasks.

The SchemaModel got a conversion method, which does the conversion.