### PR TITLE
Fix bug #2547 Python script task fails to execute

### DIFF
--- a/app/scripts/proactive/templates/script-template.html
+++ b/app/scripts/proactive/templates/script-template.html
@@ -3,9 +3,9 @@
         <% if (model["Type"]) { %> type="<%=model["Type"]%>" <% }%>>
             <% if (model["Script"] && model["Script"].length>0 && !model["Library Path"] || model["Language"]) {%>
                 <code language="<%=model["Language"]%>">
-                    <![CDATA[
-                    <%= model["Script"] %>
-                    ]]>
+<![CDATA[
+<%= model["Script"] %>
+]]>
                 </code>
             <% } else { %>
                 <% if (model["Library Path"] && model["Library Path"].length>0) { %>


### PR DESCRIPTION
Tabs spaces prevents Python (which expect correct formatting) to work correctly.