### PR TITLE
Change padding size due to su menus

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -29,7 +29,7 @@
         <!-- endbuild -->
 
     </head>
-<body data-library="jquery" style="zoom: 1;display:none; padding-top:150px">
+<body data-library="jquery" style="zoom: 1;display:none">
         <!--[if lt IE 10]>
             <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
         <![endif]-->


### PR DESCRIPTION
- Sub menus provide more space in the navigation bar, revert the previously added padding

@sophiesongge Thank you for pointing out that we changed the padding recently so that the "big" menu fits. 

This PR reverses the padding change, because the sub menus reduce the menu size significantly.

Here is the Studio with padding: 
![image](https://cloud.githubusercontent.com/assets/6491363/18270925/d6fda7ca-742f-11e6-9fac-79c76afef53e.png)

Here is the new version without padding:
![image](https://cloud.githubusercontent.com/assets/6491363/18270958/fd44140a-742f-11e6-90e2-b9d44de9ea34.png)
