### PR TITLE
Append template content to document object at first during rendering

### DIFF
--- a/app/scripts/proactive/view/LoginView.js
+++ b/app/scripts/proactive/view/LoginView.js
@@ -36,6 +36,9 @@ define(
             render: function () {
                 var that = this;
 
+                that.$el = $(that.template());
+                $('body').append(that.$el).show();
+
                 StudioClient.isConnected(function () {
                     // logged in successfully - show user name
                     console.log("Logged in");
@@ -44,10 +47,8 @@ define(
                     $('body').show();
                 }, function () {
                     // failed to login - show login form
-                    console.log("Login Required")
-                    that.$el = $(that.template())
-                    $('body').append(that.$el).show();
-                })
+                    console.log("Login Required");
+                });
 
                 return this;
             }


### PR DESCRIPTION
Template content associated to login view was not always appended to the
document object while rendering the login view with Backbone.js. Also, binding
was too late for some of the cases that were already handled. As a consequence,
the event that is defined for the Submit button was not registered by
Backbone.js and thus not triggered.

This patch fixes ow2-proactive/studio#312.