### PR TITLE
Set documentation link to dev when SNAPSHOT version

### DIFF
--- a/app/scripts/proactive/view/dom.js
+++ b/app/scripts/proactive/view/dom.js
@@ -560,14 +560,16 @@ define(
                 console.log('conf:');
                 console.log(conf);
                 if (conf.studioVersion.indexOf("SNAPSHOT") > -1){
-                    result = result + "latest";
+                    result = result + "dev";
                 }
                 else{
                     result = result + conf.studioVersion;
                 }
+
+                $("#documentationLinkId").attr("href", result);
             });
 
-        	$("#documentationLinkId").attr("href", result);
+
         	
             var ctrlDown = false;
             var ctrlKey = 17, commandKey = 91, vKey = 86, cKey = 67, zKey = 90, yKey = 89;


### PR DESCRIPTION
Set documentation link to dev when SNAPSHOT version

Problem:
- The studio portal links to www.doc.activeeon.com/
- the $.getScript is asynchronous, so documentation link is set before the latest, now dev addition was set

Solution:
- Move the $("#documentationLinkId").attr("href", result); into the $.getScript