### PR TITLE
Fix failing test

### DIFF
--- a/test/ui/specs/workflow.js
+++ b/test/ui/specs/workflow.js
@@ -96,10 +96,8 @@ module.exports = {
             .click("#data-loss-continue")
             .waitForElementVisible('#simple-form')
             .assert.elementNotPresent("#accordion-properties")
-            
-            .click("button.btn.btn-default")
+            .pause(browser.globals.menuAnimationTime)
             .click('div[name="Variables"] button')
-
             .waitForElementVisible('#Name')
             .setValue("#Name", "aVariable")
             .setValue("#Value", "aValue")


### PR DESCRIPTION
The testcase Workflow with job variable was failing because it was actually login out before doing the rest of the checks. In a local environment this doesnt happen because a notification appears on top of the log out button but with latency, the notification has enough time to disappear so the way is clear to log out. This fix is to remove the unecessary click to log out as the test is not finished.