### PR TITLE
submission form : job with no variables should not pop up the execution form

### DIFF
--- a/app/scripts/proactive/view/dom.js
+++ b/app/scripts/proactive/view/dom.js
@@ -175,7 +175,7 @@ define(
             closeCollapsedMenu();
 
             var jobVariables = readOrStoreVariablesInModel();
-            if (jobVariables == null || jobVariables.length == 0) {
+            if (jobVariables == null || $.isEmptyObject(jobVariables)) {
                 executeIfConnected(submit);
                 return;
             }


### PR DESCRIPTION
- use the isEmptyObject jquery method to test that the jobVariables object is empty