### PR TITLE
tentative fix for #357 : Inherited task variable checkbox is randomly turning on

### DIFF
--- a/app/scripts/proactive/model/utils.js
+++ b/app/scripts/proactive/model/utils.js
@@ -16,7 +16,7 @@ define(function (require) {
             "\"><input class='input-property-field' type=\"text\"  value=\""+ value + "\">";
         },
         inlineNameValueInherited: function(prop) {
-        	prop['Inherited'] = (prop['Inherited'] && prop['Inherited'] != "false");
+        	prop['Inherited'] = (prop['Inherited'] && prop['Inherited'] == "true");
         	
         	var value = prop['Value'] ? prop['Value'] : "";
         	var checked = "";


### PR DESCRIPTION

As the problem is difficult to reproduce, try to remove problems which could occur if inherited = 'undefined' string