### PR TITLE
 Fix bug of Inherited task variable checkbox is randomly turning on

### DIFF
--- a/app/scripts/proactive/templates/task-template.html
+++ b/app/scripts/proactive/templates/task-template.html
@@ -17,7 +17,8 @@
     <% if (task["Variables"] && task["Variables"].length>0) { %>
     <variables>
     <% _.each(task["Variables"], function(variable) { %>
-        <variable name="<%=variable["Name"]%>" value="<%=escapeHtml(variable.hasOwnProperty("Value")?variable["Value"]:"")%>" inherited="<%=variable["Inherited"]%>" <% if (variable.hasOwnProperty("Model") && variable["Model"].length > 0) { %>model="<%=escapeHtml(variable["Model"])%>"<% }%>/>    <% }) %>
+            <variable name="<%=variable["Name"]%>" value="<%=escapeHtml(variable.hasOwnProperty("Value")?variable["Value"]:"")%>" inherited="<%=variable["Inherited"]%>" <% if (variable.hasOwnProperty("Model") && variable["Model"].length > 0) { %>model="<%=escapeHtml(variable["Model"])%>"<% }%>/>
+    <% }) %>
     </variables>
     <% } %>
 

--- a/app/scripts/proactive/templates/task-template.html
+++ b/app/scripts/proactive/templates/task-template.html
@@ -17,8 +17,7 @@
     <% if (task["Variables"] && task["Variables"].length>0) { %>
     <variables>
     <% _.each(task["Variables"], function(variable) { %>
-            <variable name="<%=variable["Name"]%>" value="<%=escapeHtml(variable.hasOwnProperty("Value")?variable["Value"]:"")%>" <% if (variable["Inherited"]) { %>inherited="true" <% }else{ %>inherited="false"<% } %> <% if (variable.hasOwnProperty("Model")) { %>model="<%=escapeHtml(variable["Model"])%>"<% }%>/>
-    <% }) %>
+        <variable name="<%=variable["Name"]%>" value="<%=escapeHtml(variable.hasOwnProperty("Value")?variable["Value"]:"")%>" inherited="<%=variable["Inherited"]%>" <% if (variable.hasOwnProperty("Model") && variable["Model"].length > 0) { %>model="<%=escapeHtml(variable["Model"])%>"<% }%>/>    <% }) %>
     </variables>
     <% } %>
 


### PR DESCRIPTION
This change resolves #357 and partially addresses #410 (which will come next).
Additionally fixes the random appearance of "model" attribute in the task variable tag of the XML, even when the value of "model" is empty.