### PR TITLE
Improve performance of Catalog loading in the Studio

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -234,16 +234,6 @@
             </div>
         </div>
 
-        <div id="catalog-loading-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
-            <div class="modal-dialog" style="width:500px">
-                <div class="modal-content">
-                    <div class="modal-body">
-                        <h3>Loading the Catalog...</h3>
-                    </div>
-                </div>
-            </div>
-        </div>
-
         <div id="catalog-get-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
             <div class="modal-dialog" style="width:1050px">
                 <div class="modal-content">

--- a/app/scripts/proactive/model/CatalogRestBucket.js
+++ b/app/scripts/proactive/model/CatalogRestBucket.js
@@ -15,15 +15,6 @@ define(
                 owner: "",
                 created_at: "",
                 workflows: ""
-            },
-            initialize: function(options) {
-            	var that = this;
-                var workflows = new CatalogWorkflowCollection({
-                	id: this.id,
-                	callback: function(data){
-                		that.set("workflows", data);
-                	}});
-                workflows.fetch({async: false});
             }
         });
     })

--- a/app/scripts/proactive/view/CatalogGetView.js
+++ b/app/scripts/proactive/view/CatalogGetView.js
@@ -7,10 +7,11 @@ define(
         'text!proactive/templates/catalog-get-workflow.html',
         'text!proactive/templates/catalog-get-revision.html',
         'text!proactive/templates/catalog-get-revision-description.html',
-        'proactive/model/CatalogWorkflowRevisionCollection'
+        'proactive/model/CatalogWorkflowRevisionCollection',
+        'proactive/model/CatalogWorkflowCollection'
     ],
 
-    function ($, Backbone, catalogBrowser, catalogList, catalogWorkflow, catalogRevision, catalogRevisionDescription, CatalogWorkflowRevisionCollection) {
+    function ($, Backbone, catalogBrowser, catalogList, catalogWorkflow, catalogRevision, catalogRevisionDescription, CatalogWorkflowRevisionCollection, CatalogWorkflowCollection) {
 
     "use strict";
 
@@ -36,16 +37,23 @@ define(
             if (currentBucketRow){
 	        	var currentBucketID = $(currentBucketRow).data("bucketid");
 	            this.highlightSelectedRow('#catalog-get-buckets-table', currentBucketRow);
-	            
+
 	            var that = this;
                 var currentBucket = this.buckets.get(currentBucketID);
-                var workflows = currentBucket.get("workflows");
-                _.each(
-                		workflows,
-                		function (workflow) {
-            				var WorkflowList = _.template(catalogWorkflow);
-            				that.$('#catalog-get-workflows-table').append(WorkflowList({workflow: workflow}));
-                		});
+                var bucketId = that.getSelectedBucketId();
+                var workflowsModel = new CatalogWorkflowCollection(
+                {
+                    id: bucketId,
+                    callback: function (workflows) {
+                        _.each(
+                        workflows,
+                        function (workflow) {
+                            var WorkflowList = _.template(catalogWorkflow);
+                            that.$('#catalog-get-workflows-table').append(WorkflowList({workflow: workflow}));
+                        });
+                    }
+                });
+                workflowsModel.fetch({async:false});
             }
             this.internalSelectWorkflow(this.$('#catalog-get-workflows-table tr')[0]);
             

--- a/app/scripts/proactive/view/dom.js
+++ b/app/scripts/proactive/view/dom.js
@@ -130,9 +130,7 @@ define(
         $("#get-from-catalog-button").click(function (event) {
             event.preventDefault();
             var studioApp = require('StudioApp');
-            $('#catalog-loading-modal').modal();
             studioApp.models.catalogBuckets.fetch({reset: true, async: false});
-            $('#catalog-loading-modal').modal('hide');
             studioApp.modelsToRemove = [];
             studioApp.views.catalogGetView.render();
             $('#catalog-get-modal').modal();
@@ -142,9 +140,7 @@ define(
             event.preventDefault();
             var studioApp = require('StudioApp');
             if (studioApp.isWorkflowOpen()){
-                $('#catalog-loading-modal').modal();
                 studioApp.models.catalogBuckets.fetch({reset: true, async: false});
-                $('#catalog-loading-modal').modal('hide');
                 studioApp.modelsToRemove = [];
                 studioApp.views.catalogPublishView.render();
                 $('#catalog-publish-modal').modal();


### PR DESCRIPTION
When opening "Get a Workflow from the Catalog" and "Publish current Workflow to the Catalog" windows, we ask server for every workflow of every buckets to display them. This takes too much time so we will only load buckets and once a bucket is selected, we will load its workflows. 