### PR TITLE
Allow to change logo in studio

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,16 @@ task packageDev(type: Zip) {
     classifier 'dev'
 }
 
+if (project.hasProperty('customizableSquaredLogoLocation')
+        && project.hasProperty('customizableImages')) {
+    task replaceCustomizableImage(type: ReplaceFilesTask) {
+        newFileUrl = project.customizableSquaredLogoLocation
+        commaSeparatedListFilesToOverwrite = project.customizableImages
+    }
+
+    build.finalizedBy(replaceCustomizableImage)
+}
+
 artifacts {
     if (file('dist').exists()) {
         archives packageDist, packageDev
@@ -53,6 +63,7 @@ buildscript {
     dependencies {
         classpath "com.diffplug.gradle.spotless:spotless:2.4.0"
         classpath "org.ow2.proactive:coding-rules:1.0.0"
+        classpath "org.ow2.proactive:replace-files-gradle-plugin:0.1.5"
         delete "gradle/ext"
         ant.unjar src: configurations.classpath.find { it.name.startsWith("coding-rules") }, dest: 'gradle/ext'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,5 @@
 #Tue, 24 Oct 2017 11:00:47 +0200
 studioVersion=7.32.0-SNAPSHOT
+
+customizableImages = dist/images/company-icon-squared.png
+#customizableSquaredLogoLocation = https://nice-logo


### PR DESCRIPTION
If the property customizableSquaredLogoLocation will be set to an url, the studio placeholder image will be overwritten with the file behind that url.