### PR TITLE
Lists that contain strings have the same remove button as other lists

### DIFF
--- a/app/scripts/proactive/model/CatalogWorkflowCollection.js
+++ b/app/scripts/proactive/model/CatalogWorkflowCollection.js
@@ -17,7 +17,7 @@ define(
                     this.callback = options.callback;
                 },
                 url: function() {
-                    return '/catalog/buckets/' + this.id + '/resources';
+                    return '/catalog/buckets/' + this.id + '/resources/?kind=workflow';
                 },
                 parse: function(data) {
                     if (this.callback)

--- a/app/scripts/proactive/model/ForkEnvironment.js
+++ b/app/scripts/proactive/model/ForkEnvironment.js
@@ -2,10 +2,11 @@ define(
     [
         'backbone',
         'proactive/model/SchemaModel',
-        'proactive/model/Script'
+        'proactive/model/Script',
+        'proactive/model/utils'
     ],
 
-    function (Backbone, SchemaModel, Script) {
+    function (Backbone, SchemaModel, Script, Utils) {
 
         "use strict";
 
@@ -25,7 +26,8 @@ define(
                         'placeholder': 'jvmArgs->jvmArg',
                         'itemplaceholder': '@attributes->value',
                         "data-help": 'JVM properties e.g:<br/>-Xmx2G<br/>-Dprop.name=value'
-                    }
+                    },
+                    itemTemplate: Utils.bigCrossTemplate
                 },
                 "Working Folder": {
                     type: "Text",
@@ -41,7 +43,8 @@ define(
                         'placeholder': 'additionalClasspath->pathElement',
                         'itemplaceholder': '@attributes->path',
                         "data-help": 'The list of \"pathElement\" representing the classpath to be added when starting the new JVM.'
-                    }
+                    },
+                    itemTemplate: Utils.bigCrossTemplate
                 },
                 "Environment Variables": {
                     type: 'List',
@@ -53,7 +56,8 @@ define(
                     subSchema: {
                         "Name": {type: "Text", fieldAttrs: {'placeholder': '@attributes->name'}},
                         "Value": {type: "Text", fieldAttrs: {'placeholder': '@attributes->value'}},
-                    }
+                    },
+                    itemTemplate: Utils.bigCrossTemplate
                 },
                 "Environment Script": {
                     type: 'NestedModel',

--- a/app/scripts/proactive/model/NativeExecutable.js
+++ b/app/scripts/proactive/model/NativeExecutable.js
@@ -2,10 +2,11 @@ define(
     [
         'backbone',
         'proactive/model/SchemaModel',
-        'proactive/model/Script'
+        'proactive/model/Script',
+        'proactive/model/utils'
     ],
 
-    function (Backbone, SchemaModel, Script) {
+    function (Backbone, SchemaModel, Script, Utils) {
 
         "use strict";
 
@@ -20,12 +21,13 @@ define(
             },
             "Arguments": {
                 type: 'List', 
-                itemType: 'Text', 
+                itemType: 'Text',
                 fieldAttrs: {
                     'placeholder': 'staticCommand->arguments->argument', 
                     'itemplaceholder': '@attributes->value', 
                     "data-help":'Command line arguments. Do not use space as a separator for arguments. Rather add all of arguments one by one to the list.'
-                }
+                },
+                itemTemplate: Utils.bigCrossTemplate
             },
         }
     })

--- a/app/scripts/proactive/model/Task.js
+++ b/app/scripts/proactive/model/Task.js
@@ -26,8 +26,6 @@ define(
 
         "use strict";
 
-        var bigCrossTemplate = _.template('<div><span data-editor></span><button type="button" class="btn btn-danger" data-action="remove">x</button></div>');
-
         var Task = SchemaModel.extend({
             schema: {
                 "Task Name": {
@@ -54,7 +52,7 @@ define(
                     fieldAttrs: {
                         'placeholder': 'variables->variable',
                         "data-help":"<li><b>Name</b>: Name of the variable</li><li><b>Value</b>: Value of the variable</li><li><b>Inherited</b>: Job Variable&#39;s value will be used</li>"},
-                    itemToString: Utils.inlineNameValueInherited, itemTemplate: bigCrossTemplate,
+                    itemToString: Utils.inlineNameValueInherited, itemTemplate: Utils.bigCrossTemplate,
                     subSchema: {
                     "Name": { validators: ['required'], fieldAttrs: {'placeholder': '@attributes->name'}, title: 'Name', type: 'Text', editorClass: 'popup-input-text-field' },
                     "Value": { fieldAttrs: {'placeholder': '@attributes->value'}, title: 'Value', type: 'Text', editorClass: 'popup-input-text-field' },
@@ -70,7 +68,7 @@ define(
                         'placeholder': 'genericInformation->info',
                         "data-help": 'Some extra information about your job often used to change the scheduling behavior for a job. E.g. NODE_ACCESS_TOKEN=rack1 will assign this task to a node with token \"rack1\".'
                     },
-                    itemToString: Utils.inlineNameValue, itemTemplate: bigCrossTemplate,
+                    itemToString: Utils.inlineNameValue, itemTemplate: Utils.bigCrossTemplate,
                     subSchema: {
                         "Property Name": {
                             validators: ['required'],
@@ -108,7 +106,7 @@ define(
                             options: ["transferFromUserSpace", "transferFromGlobalSpace", "transferFromInputSpace", "transferFromOutputSpace","cacheFromUserSpace", "cacheFromGlobalSpace", "cacheFromInputSpace", "cacheFromOutputSpace", "none"]
                         }
                     },
-                    itemTemplate: bigCrossTemplate,
+                    itemTemplate: Utils.bigCrossTemplate,
                     confirmDelete: 'You are about to remove an input file.'
                 },
                 "Output Files": {
@@ -127,7 +125,7 @@ define(
                             options: ["transferToUserSpace", "transferToGlobalSpace", "transferToOutputSpace", "none"]
                         }
                     },
-                    itemTemplate: bigCrossTemplate,
+                    itemTemplate: Utils.bigCrossTemplate,
                     confirmDelete: 'You are about to remove an output file.'
                 },
                 "Precious Result": {
@@ -298,7 +296,7 @@ define(
                         else
                             return "<u style='cursor: pointer;'>Selection script </u>";
                     },
-                    itemTemplate: bigCrossTemplate,
+                    itemTemplate: Utils.bigCrossTemplate,
                     fieldAttrs: {
                         "data-tab": "Node Selection",
                         'placeholder': 'selection->script',

--- a/app/scripts/proactive/model/utils.js
+++ b/app/scripts/proactive/model/utils.js
@@ -1,32 +1,38 @@
-define(function (require) {
+define(
+    [
+        'backbone'
+    ],
+
+    function (Backbone) {
 	
-    return {
-    	inlineName: function(prop) {
-            var name = prop['Name'] ? prop['Name'] : prop['Property Name'];
-            return name;
-        },
-        inlineNameValueNotEditable: function(prop) {
-            return "<div class='property-field'>" + prop['Name'] + "</div><div class='property-field'>" + prop["Value"] + "</div>";
-        },
-        inlineNameValue: function(prop) {   
-            var name = prop['Name'] ? prop['Name'] : prop['Property Name'];
-            var value = prop['Value'] ? prop['Value'] : prop['Property Value'];
-            
-            return "<input class='input-property-field' type=\"text\" value=\"" + name + 
-            "\"><input class='input-property-field' type=\"text\"  value=\""+ value + "\">";
-        },
-        inlineNameValueInherited: function(prop) {
-        	prop['Inherited'] = (prop['Inherited'] && (prop['Inherited'] == true || prop['Inherited'] == "true"));
-        	
-        	var value = prop['Value'] ? prop['Value'] : "";
-        	var checked = "";
-        	if (prop['Inherited']){
-        		checked=" checked"
-        	}
-        			
-            return "<input class='input-property-field' type=\"text\" value=\"" + prop['Name'] + 
-            "\"><input class='input-property-field' type=\"text\"  value=\""+ value +
-            "\"><input class='input-property-field' type=\"checkbox\"" + checked + " onclick=\"return false;\">";
+        return {
+            inlineName: function(prop) {
+                var name = prop['Name'] ? prop['Name'] : prop['Property Name'];
+                return name;
+            },
+            inlineNameValueNotEditable: function(prop) {
+                return "<div class='property-field'>" + prop['Name'] + "</div><div class='property-field'>" + prop["Value"] + "</div>";
+            },
+            inlineNameValue: function(prop) {
+                var name = prop['Name'] ? prop['Name'] : prop['Property Name'];
+                var value = prop['Value'] ? prop['Value'] : prop['Property Value'];
+
+                return "<input class='input-property-field' type=\"text\" value=\"" + name +
+                "\"><input class='input-property-field' type=\"text\"  value=\""+ value + "\">";
+            },
+            inlineNameValueInherited: function(prop) {
+                prop['Inherited'] = (prop['Inherited'] && (prop['Inherited'] == true || prop['Inherited'] == "true"));
+
+                var value = prop['Value'] ? prop['Value'] : "";
+                var checked = "";
+                if (prop['Inherited']){
+                    checked=" checked"
+                }
+
+                return "<input class='input-property-field' type=\"text\" value=\"" + prop['Name'] +
+                "\"><input class='input-property-field' type=\"text\"  value=\""+ value +
+                "\"><input class='input-property-field' type=\"checkbox\"" + checked + " onclick=\"return false;\">";
+            },
+            bigCrossTemplate: _.template('<div><span data-editor></span><button type="button" class="btn btn-danger" data-action="remove">x</button></div>')
         }
-    }
 })


### PR DESCRIPTION
On the properties panel, lists that contain strings (Jvm Arguments, Additional Classpath & Arguments for native task implementation)  have the same remove button as other lists 
& only workflows in templates menu