### PR TITLE
FIX issue #488 related to empty task names

### DIFF
--- a/app/scripts/proactive/view/TaskView.js
+++ b/app/scripts/proactive/view/TaskView.js
@@ -88,6 +88,22 @@ define(
             PNotify.removeAll();
             taskNameInputField.css({ "border": "" });
 
+            // Prevent having empty task names. Nameless tasks do not affect the scheduler but cannot be removed from studio unless they get a name.
+            if (!newTaskName) {
+                new PNotify({
+                    title: "Task Name should not be empty",
+                    type: "error",
+                    text_escape: false,
+                    buttons: {
+                        closer: true,
+                        sticker: false
+                    },
+                    opacity: .8,
+                    width: '20%'
+                });
+                taskNameInputField.css({ "border": "1px solid #D2322D"});
+            }
+
             // if there is another task with same name as the current one
             // there will be at least two tasks detected with same name
             // since variable existingTasks contains all tasks, including


### PR DESCRIPTION
In this PR, we fix the issue described in #488  that prevents nameless tasks from being removed unless they get a name.
The applied solution consists in notifying the user as shown in the attached screenshot.
**Note:** We followed the same behaviour as when the user gives a duplicate name to the task.
 
![capture d ecran 2017-12-29 a 11 26 01](https://user-images.githubusercontent.com/1918419/34435069-1b013084-ec8b-11e7-98d5-5e8719e6793a.png)


(Of course, the issue does not affect the scheduler because workflows with nameless tasks cannot be submitted to the scheduler).