### PR TITLE
 Fixing bug when importing from catalog and a workflow is already opened

### DIFF
--- a/app/scripts/proactive/app.js
+++ b/app/scripts/proactive/app.js
@@ -192,11 +192,11 @@ define(
             return this.views.xmlView != null;
         },
         openWorkflowFromCatalog : function(bucketName, workflowName) {
-            var studioApp = require('StudioApp');
+            var that = this;
             var url = '/catalog/buckets/' + bucketName + '/resources/'+workflowName+ '/raw';
             dom.getWorkflowFromCatalog(url, function (response) {
-                studioApp.xmlToImport = new XMLSerializer().serializeToString(response);
-                dom.add_workflow_to_current(true);
+                that.xmlToImport = new XMLSerializer().serializeToString(response);
+                dom.open_catalog_workflow();
             });
         }
     };

--- a/app/scripts/proactive/view/WorkflowListView.js
+++ b/app/scripts/proactive/view/WorkflowListView.js
@@ -153,7 +153,7 @@ define(['jquery',
                 }
                 var app = this.options.app;
                 app.import(model);
-                app.router.navigate("workflows/" + model.get('id'));
+                app.router.navigate("workflows/" + model.get('id'), {trigger: true});
             },
             saveCurrentWorkflow: function (name, workflowXml, metadata) {
                 this._currentWorkflow().save(

--- a/app/scripts/proactive/view/WorkflowListView.js
+++ b/app/scripts/proactive/view/WorkflowListView.js
@@ -153,7 +153,7 @@ define(['jquery',
                 }
                 var app = this.options.app;
                 app.import(model);
-                app.router.navigate("workflows/" + model.get('id'), {trigger: true});
+                app.router.navigate("workflows/" + model.get('id'));
             },
             saveCurrentWorkflow: function (name, workflowXml, metadata) {
                 this._currentWorkflow().save(

--- a/app/scripts/proactive/view/dom.js
+++ b/app/scripts/proactive/view/dom.js
@@ -526,6 +526,26 @@ define(
                 studioApp.importFromCatalog();
                 console.log("A workflow was imported!");
                 $('#catalog-get-close-button').click();
+                if(redirectsWhenOpened) {
+                    var router = studioApp.router;
+                    router.navigate("workflows/"+ studioApp.models.currentWorkflow.id);
+                }
+            }
+            else {
+                // create a new workflow, open it and import the xml into it
+                var clickAndOpenEvent = jQuery.Event( "click" );
+                clickAndOpenEvent.openWorkflow = true;
+                $('.create-workflow-button').trigger(clickAndOpenEvent);
+            }
+        }
+
+        function open_catalog_workflow() {
+            var studioApp = require('StudioApp');
+
+            // If a worklfow is already opened, we don't import it (we would lose the current one)
+            if (studioApp.isWorkflowOpen()) {
+                var router = studioApp.router;
+                router.navigate("workflows/"+ studioApp.models.currentWorkflow.id, {trigger: true});
             }
             else {
                 // create a new workflow, open it and import the xml into it
@@ -846,7 +866,7 @@ define(
        return {
            saveWorkflow: save_workflow,
            getWorkflowFromCatalog : getWorkflowFromCatalog,
-           add_workflow_to_current : add_workflow_to_current
+           open_catalog_workflow : open_catalog_workflow
        };
 
     });

--- a/app/scripts/proactive/view/dom.js
+++ b/app/scripts/proactive/view/dom.js
@@ -526,10 +526,6 @@ define(
                 studioApp.importFromCatalog();
                 console.log("A workflow was imported!");
                 $('#catalog-get-close-button').click();
-                if(redirectsWhenOpened) {
-                    var router = studioApp.router;
-                    router.navigate("workflows/"+ studioApp.models.currentWorkflow.id);
-                }
             }
             else {
                 // create a new workflow, open it and import the xml into it

--- a/app/scripts/proactive/view/dom.js
+++ b/app/scripts/proactive/view/dom.js
@@ -542,7 +542,7 @@ define(
         function open_catalog_workflow() {
             var studioApp = require('StudioApp');
 
-            // If a worklfow is already opened, we don't import it (we would lose the current one)
+            // If a workflow is already opened, we don't import it (we would lose the current one)
             if (studioApp.isWorkflowOpen()) {
                 var router = studioApp.router;
                 router.navigate("workflows/"+ studioApp.models.currentWorkflow.id, {trigger: true});


### PR DESCRIPTION
It is not possible to import a workflow from catalog using URL feature : it would replace the current workflow. When entering a URL for workflow import and the workflow is opened, the page stays the same and the action is ignored.