### PR TITLE
Update ejs and hoek vulnerable dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -998,7 +998,7 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "ejs": {
-      "version": "0.8.3",
+      "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-0.8.3.tgz",
       "integrity": "sha1-24qsR/+Ap9+CtMgsEm/olwhwYm8="
     },
@@ -1915,7 +1915,7 @@
       "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0="
     },
     "hoek": {
-      "version": "2.16.3",
+      "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -999,7 +999,7 @@
     },
     "ejs": {
       "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-0.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.5.tgz",
       "integrity": "sha1-24qsR/+Ap9+CtMgsEm/olwhwYm8="
     },
     "encodeurl": {
@@ -1916,7 +1916,7 @@
     },
     "hoek": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "hooker": {


### PR DESCRIPTION
Critical vulnerabilities (including RCE and DoS) have been found in some dependencies. I believe exploitation of such vuln. can be automated - better to update the dependencies therefore.

NodeJS EJS vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2017-1000188
https://nvd.nist.gov/vuln/detail/CVE-2017-1000228
https://nvd.nist.gov/vuln/detail/CVE-2017-1000189

Hoek vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2018-3728