### PR TITLE
Fix for #576 Fork Environment Code and Language are lost when set to Docker

### DIFF
--- a/app/scripts/proactive/model/ForkEnvironment.js
+++ b/app/scripts/proactive/model/ForkEnvironment.js
@@ -67,9 +67,6 @@ define(
                         "data-help": 'A script which can be used to configure programmatically the task&#39;s forked JVM process. The environment script is run before any other task script (pre, task, etc).'
                     }
                 }
-            },
-            initialize: function() {
-                this.set({"Environment Script": new ForkEnvironmentScript()});
             }
         })
     })


### PR DESCRIPTION

Removed the initialization of the model which was overwriting already entered script.