### PR TITLE
Fixing issues #596 & #568: Wrong user displayed

### DIFF
--- a/app/scripts/proactive/rest/studio-client.js
+++ b/app/scripts/proactive/rest/studio-client.js
@@ -169,13 +169,13 @@ define(
 
             //customize client side, set localStorage['pa.login'] with server username for current session
             setCurrentUser : function () {
-                var that = this;
                 $.ajax({
                     type: 'GET',
                     url: config.restApiUrl + "/currentuser",
                     beforeSend: function(xhr) {
                         xhr.setRequestHeader('sessionid', localStorage['pa.session']);
                     },
+                    async: false,
                     success: function(data) {
                         //does not  return a json so even in case of success goes to error callback
                         console.log("Should not be here")


### PR DESCRIPTION
logout view (so user name) was built before setCurrentUser was finished. Adding 'async' fixed the problem, now we wait for the currentUser request to be done to start building the logout view