### PR TITLE
Make imported catalog scripts urls relative

### DIFF
--- a/app/scripts/proactive/view/CatalogGetView.js
+++ b/app/scripts/proactive/view/CatalogGetView.js
@@ -213,7 +213,8 @@ define(
                 var inputToImport = document.getElementById(that.inputToImportId);
                 var isUrlImport = that.inputToImportId.indexOf('_Url') > -1;
                 if (isUrlImport) //if input id contains 'Url', we only import the URL of the selected catalog object
-                    inputToImport.value = $("#catalog-get-revision-description").data("selectedrawurl");
+                    // if catalog host is the same as the studio, make catalog object url relative with ${PA_CATALOG_REST_URL}.
+                    inputToImport.value = $("#catalog-get-revision-description").data("selectedrawurl").replace(window.location.origin + '/catalog/','${PA_CATALOG_REST_URL}/');
                 else //Otherwise, we import the content of the catalog object
                     inputToImport.value = response;
                 $('#catalog-get-close-button').click();

--- a/app/scripts/proactive/view/dom.js
+++ b/app/scripts/proactive/view/dom.js
@@ -793,9 +793,15 @@ define(
                 if (isUrl) {
                     if (inputValue.trim()!='') {
                         var isCatalogScript = inputValue.startsWith(window.location.origin + '/catalog/');
+                        // Check if catalog object URL is relative (using ${PA_CATALOG_REST_URL})
+                        var isRelativeCatalogScript = inputValue.startsWith('${PA_CATALOG_REST_URL}');
                         var headers = {};
-                        if (isCatalogScript) {
+                        if (isCatalogScript || isRelativeCatalogScript) {
                             headers = { 'sessionID': localStorage['pa.session'] };
+                        }
+                        // Replace ${PA_CATALOG_REST_URL} with an absolute URL.
+                        if (isRelativeCatalogScript){
+                            inputValue = inputValue.replace('${PA_CATALOG_REST_URL}',window.location.origin + '/catalog/');
                         }
                         $.ajax({
                             url: inputValue,


### PR DESCRIPTION
In this PR, we make sure that imported scripts from the catalog are displayed in a relative way in the script URL text field using the `${PA_CATALOG_REST_URL}` instead of an absolute URL.
We also make the edit script action compatible with such relative urls