### PR TITLE
Improve Calalog palette with new features and bug fixes

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -202,20 +202,30 @@
                 <td id="left-panel-properties">
                     <div id="properties-container"></div>
                 </td>
-                <td style="height:100%;width:75%; padding-right:10px;">
+                <td style="height:100%;width:75%; padding-right:5px;">
                     <div id="workflow-designer-outer">
                         <table id="tools-table">
                             <tr>
-                                <td id="palette-container" style="padding-right:20px">
-                                </td>
-                                <td>
-                                    <div id="tools-panel">
+                                <td id="palette-container">
+                                    <div style="display: inline-flex;">
                                         <div class="btn-group">
                                             <button id="layout-button" type="button" class="btn"
-                                                    title="Layout"><i
-                                                class="glyphicon glyphicon-align-center"></i></button>
+                                                    title="Auto layout">
+                                                <i class="glyphicon glyphicon-align-center"></i>
+                                            </button>
                                         </div>
-                                    </div>
+                                        <div id="palette-container-div"></div>
+                                        <div class="btn-group">
+                                            <button id="add-bucket-button" type="button" class="btn"
+                                                    title="Add bucket">
+                                                <i class="glyphicon glyphicon-plus"></i>
+                                            </button>
+                                            <button id="pin-palette-button" type="button" class="btn"
+                                                    title="Pin Catalog menu">
+                                                <img width="13px" src="images/icon-unpin.png">
+                                            </button>
+                                        </div>
+                                </div>
                                 </td>
                             </tr>
                         </table>

--- a/app/scripts/proactive/view/PaletteView.js
+++ b/app/scripts/proactive/view/PaletteView.js
@@ -13,10 +13,7 @@ define(
         return Backbone.View.extend({
 
         initialize: function () {
-            this.$el = $("<div></div>");
-            $("#palette-container").append(this.$el);
-
-
+            this.$el = $("#palette-container-div");
             if (!localStorage['secondaryBucketNames'])
                 localStorage.setItem('secondaryBucketNames',"[]");
             this.options.app.models.secondaryTemplates = {};
@@ -39,14 +36,23 @@ define(
                         menu.append(subMenu);
                         subMenu.data("templateName", property);
                         subMenu.data("templateUrl", template[property]);
-                        subMenu.draggable({helper: "clone", scroll: true, distance:0});
+                        subMenu.draggable({helper: "clone", scroll: true, appendTo: "#workflow-designer", opacity:0.85, zIndex: 999, containment:"#workflow-designer"});
+                        subMenu.bind("drag", function(event, ui) {
+                            ui.helper.css("background-color", "white");
+                            ui.helper.css("padding", "3px 20px");
+                        });
+                        subMenu.click(function(event) {
+                            // simulating drag and drop of this element
+                            var workflowView = that.options.app.views.workflowView
+                            workflowView.dropElement(event, {draggable:this, offset: {left: event.pageX, top: event.pageY}})
+                        })
                     }
                 }
             }
         },
-        pinUnpin : function(e){
+        pinUnpin : function(){
             var menuElement = $(this).parent().parent();
-            var keepFromClosing = function(event){
+            var keepFromClosing = function(){
                 return false;
             };
             if(menuElement.hasClass('dropdown')){ //not pinned yet
@@ -60,10 +66,26 @@ define(
                 $(this).html('<img src="images/icon-pin.png"> Pin open');
             }
         },
-        setPin : function(menu){
+        setPinMenu : function(menu){
             var pinOpen = $('<li role="presentation" class="dropdown-header"><img src="images/icon-pin.png"> Pin open</li>');
             pinOpen.on('click', this.pinUnpin);
             menu.append(pinOpen);
+        },
+        isPalettePinned : function(){
+            var lockStatus = $('#tools-table').css('position')
+            return (lockStatus==='sticky'||lockStatus==='-webkit-sticky');
+        },
+        pinPalette : function(){
+            if (this.isPalettePinned()) {
+                $('#tools-table').toggleClass('unpinned');
+                $('#pin-palette-button').html('<img width="14px" src="images/icon-pin.png">');
+                $('.templates-menu.locked').toggleClass("locked");
+
+            } else {
+                $('#tools-table').toggleClass('unpinned');
+                $('#pin-palette-button').html('<img width="14px" src="images/icon-unpin.png">');
+                $('.templates-menu').toggleClass("locked");
+            }
         },
         setPositionRelativeToAbsoluteEvent : function(event, ui) {
             if (this.style.position != "absolute") {
@@ -76,34 +98,33 @@ define(
         initMenu: function(menu, config) {
             menu.draggable({helper: "original", distance : 20, stop : this.setPositionRelativeToAbsoluteEvent});
             menu.addClass("dropdown");
-            var menuContent = $('<ul class="dropdown-menu templates-menu" role="menu" aria-labelledby="dropdown-templates-menu"></ul>');
-            this.setPin(menuContent);
+            var menuContent = $('<ul class="dropdown-menu templates-menu locked" role="menu" aria-labelledby="dropdown-templates-menu"></ul>');
+            this.setPinMenu(menuContent);
             this.createMenuFromConfig(config, menuContent);
             menu.append(menuContent);
         },
         render: function () {
             this.$el.html('');
-            var that = this;
             var taskWidget = $(
-                '<span ><span id="task-menu" class="label job-element job-element top-level-menu btn dropdown-toggle" data-toggle="dropdown">' +
-                    '<img src="images/gears.png" width="30px" type="button" >Tasks<span class="caret"></span></span></span>');
+                '<span class="palette"><span id="task-menu" class="label job-element top-level-menu btn dropdown-toggle" data-toggle="dropdown">' +
+                    '<img src="images/gears.png" width="20px" type="button" >Tasks<span class="caret"></span></span></span>');
 
             this.initMenu($(taskWidget), config.tasks);
 
             var manualWidget = $(
-                '<span ><span class="label job-element top-level-menu btn dropdown-toggle" data-toggle="dropdown">' +
+                '<span class="palette"><span class="label job-element top-level-menu btn dropdown-toggle" data-toggle="dropdown">' +
                     '<img src="images/gears.png" width="20px" type="button" >Manuals<span class="caret"></span></span></span>');
 
             this.initMenu($(manualWidget), config.manuals);
 
             var controlWidget = $(
-                '<span ><span class="label job-element top-level-menu btn dropdown-toggle" data-toggle="dropdown">' +
+                '<span class="palette"><span class="label job-element top-level-menu btn dropdown-toggle" data-toggle="dropdown">' +
                     '<img src="images/gears.png" width="20px" type="button" >Controls<span class="caret"></span></span></span>');
 
             this.initMenu($(controlWidget), config.controls);
             this.$el.append(taskWidget).append(manualWidget).append(controlWidget);
 
-            this.renderTemplateMainBucket();
+            this.renderTemplateMainBucket(this.mainBucketName);
             var localStorageTemplates = JSON.parse(localStorage.getItem('secondaryBucketNames'));
             var that = this;
             localStorageTemplates.forEach(function(secondaryBucketName) {
@@ -139,21 +160,21 @@ define(
                 return bucketName.replace('_',' ').replace('-',' ');
             }
         },
-        renderTemplateMainBucket : function() {
+        renderTemplateMainBucket : function(bucketName) {
             //rendering page title
-            var nameToDisplay = this.beautifyBucketName(this.mainBucketName);
+            var nameToDisplay = this.beautifyBucketName(bucketName);
             var divBucketName = $("<div id='bucket-name-title'>"+ nameToDisplay +"</div>");
             $("#studio-bucket-title").empty();
             $("#studio-bucket-title").append(divBucketName);
 
             //adding palette
             var templateWidget = $(
-                '<span ><span class="label job-element top-level-menu btn dropdown-toggle" data-toggle="dropdown">' +
-                    '<img src="images/gears.png" width="20px" type="button" >'+ this.mainBucketName +'<span class="caret"></span></span></span>');
+                '<span class="main-palette palette" id="main-palette-'+bucketName+'"><span class="label job-element top-level-menu btn dropdown-toggle" data-toggle="dropdown">' +
+                    '<img src="images/gears.png" width="20px" type="button" >'+ nameToDisplay +'<span class="caret"></span></span></span>');
             templateWidget.draggable({helper: "original", distance : 20, stop : this.setPositionRelativeToAbsoluteEvent});
             templateWidget.addClass("dropdown");
-            var menuContent = $('<ul class="dropdown-menu templates-menu" role="menu" aria-labelledby="dropdown-templates-menu"></ul>');
-            this.setPin(menuContent);
+            var menuContent = $('<ul class="dropdown-menu templates-menu locked" role="menu" aria-labelledby="dropdown-templates-menu"></ul>');
+            this.setPinMenu(menuContent);
             $(templateWidget).append(menuContent);
 
             var that = this;
@@ -177,8 +198,12 @@ define(
                         menuItem.tooltip();
                         menuContent.append(menuItem);
                         menuItem.data("templateName", template.get("name"));
-                        menuItem.data("bucketName", that.mainBucketName);
-                        menuItem.draggable({helper: "clone", scroll: true});
+                        menuItem.data("bucketName", bucketName);
+                        menuItem.draggable({helper: "clone", scroll: true, appendTo: "#workflow-designer", opacity:0.85, zIndex: 999, containment:"#workflow-designer"});
+                        menuItem.bind("drag", function(event, ui) {
+                            ui.helper.css("background-color", "white");
+                            ui.helper.css("padding", "3px 20px");
+                        });
 
                         menuItem.click(function(event) {
                             // simulating drag and drop of this element
@@ -186,16 +211,14 @@ define(
                             workflowView.dropElement(event, {draggable:this, offset: {left: event.pageX, top: event.pageY}})
                         })
                     }
-
-
                 })
             }, this);
             this.$el.append(templateWidget);
         },
         setTemplateMainBucket: function(bucketName){
-              var defaultBucketName = config.examples_bucket;
-                if (!bucketName)
-            bucketName = defaultBucketName;
+            var defaultBucketName = config.examples_bucket;
+            if (!bucketName)
+                bucketName = defaultBucketName;
             var that = this;
             this.checkAndGetBucketByName(bucketName, true, function(foundBucket){
                 if (foundBucket){
@@ -221,15 +244,15 @@ define(
         },
         renderSecondaryBucket : function(secondaryTemplates,bucketName){
             var nameToDisplay = this.beautifyBucketName(bucketName);
-            var secondaryTemplateWidget = $(
-                '<span class="secondary-palette" id="secondary-palette-'+bucketName+'"><span class="label job-element top-level-menu btn dropdown-toggle" data-toggle="dropdown">' +
+            var templateWidget = $(
+                '<span class="secondary-palette palette" id="secondary-palette-'+bucketName+'"><span class="label job-element top-level-menu btn dropdown-toggle" data-toggle="dropdown">' +
                     '<img src="images/gears.png" width="20px" type="button" >'+ nameToDisplay +'<span class="caret"></span></span>'+
                     '<span class="label top-level-menu btn remove-secondary-bucket-btn" id="remove-secondary-bucket-btn-'+bucketName+'">&times;</span></span>');
-            secondaryTemplateWidget.draggable({helper: "original", distance : 20, stop : this.setPositionRelativeToAbsoluteEvent});
-            secondaryTemplateWidget.addClass("dropdown");
-            var menuContent = $('<ul class="dropdown-menu templates-menu" role="menu" aria-labelledby="dropdown-secondary-templates-menu"></ul>');
-            this.setPin(menuContent);
-            $(secondaryTemplateWidget).append(menuContent);
+            templateWidget.draggable({helper: "original", distance : 20, stop : this.setPositionRelativeToAbsoluteEvent});
+            templateWidget.addClass("dropdown");
+            var menuContent = $('<ul class="dropdown-menu templates-menu locked" role="menu" aria-labelledby="dropdown-secondary-templates-menu"></ul>');
+            this.setPinMenu(menuContent);
+            $(templateWidget).append(menuContent);
             secondaryTemplates.groupByProject(function (project, templates) {
                 var header = $('<li role="presentation" class="dropdown-header">'+project+'</li>');
                 menuContent.append(header);
@@ -251,7 +274,11 @@ define(
                         menuContent.append(menuItem);
                         menuItem.data("templateName", template.get("name"));
                         menuItem.data("bucketName", bucketName);
-                        menuItem.draggable({helper: "clone", scroll: true});
+                        menuItem.draggable({helper: "clone", scroll: true, appendTo: "#workflow-designer", opacity:0.85, zIndex: 999, containment:"#workflow-designer"});
+                        menuItem.bind("drag", function(event, ui) {
+                           ui.helper.css("background-color", "white");
+                            ui.helper.css("padding", "3px 20px");
+                        });
 
                         menuItem.click(function(event) {
                             // simulating drag and drop of this element
@@ -261,7 +288,8 @@ define(
                     }
                 })
             }, this);
-            this.$el.append(secondaryTemplateWidget);
+            this.$el.append(templateWidget);
+            // Add remove bucket from palette action
             var that = this;
             $('#remove-secondary-bucket-btn-'+bucketName).click(function(){
                 $('#secondary-palette-'+bucketName).remove();

--- a/app/scripts/proactive/view/WorkflowView.js
+++ b/app/scripts/proactive/view/WorkflowView.js
@@ -240,7 +240,9 @@ define(
 
             view.addSourceEndPoint('dependency')
 
-            jsPlumb.draggable(rendering.$el)
+            jsPlumb.draggable(rendering.$el);
+            // Prevent dragged tasks from hiding under the left panel
+            $(rendering.$el).draggable({containment:"#workflow-designer"});
             this.taskViews.push(view);
 
             rendering.$el.data("view", view);

--- a/app/scripts/proactive/view/dom.js
+++ b/app/scripts/proactive/view/dom.js
@@ -295,6 +295,16 @@ define(
             require('StudioApp').views.workflowView.autoLayout();
             save_workflow();
         });
+
+        $("#add-bucket-button").click(function (event) {
+            event.preventDefault();
+            openSetTemplatesMenuModal('secondary');
+        });
+
+        $("#pin-palette-button").click(function (event) {
+            event.preventDefault();
+            require('StudioApp').views.palleteView.pinPalette();
+        });
         $("#zoom-in-button").click(function (event) {
             event.preventDefault();
             require('StudioApp').views.workflowView.zoomIn();

--- a/app/styles/studio.css
+++ b/app/styles/studio.css
@@ -40,13 +40,13 @@ footer {
     position: relative;
 }
 
-#left-panel-properties{
+#left-panel-properties {
     height: 100%;
     min-width: 300px;
     width: 25%;
-    padding-left: 10px;
-    padding-right: 10px;
-    padding-top: 10px;
+    padding-left: 5px;
+    padding-right: 5px;
+    padding-top: 5px;
 }
 
 #properties-container {
@@ -71,17 +71,30 @@ footer {
 }
 
 #tools-table {
-    position: absolute;
-    top: 30px;
-    left: 30%;
-    right: 30%;
+    position: sticky;
+    position: -webkit-sticky;
+    top: 15px;
+    left: 0px;
+    right: 0px;
     margin: 0 auto;
-    z-index: 1000;
+    z-index: 900;
+    width: 100%;
 }
 
-#palette-container p {
-    margin: 0;
-    width: 80px;
+#tools-table.unpinned {
+    position: relative;
+}
+
+#palette-container {
+    padding: 0px 10px 0px 10px;
+    width: 100%;
+}
+
+.btn-group {
+    width: max-content;
+    height: max-content;
+    display: inline-flex;
+    margin-top: -2px;
 }
 
 .btn .caret {
@@ -359,6 +372,7 @@ path, ._jsPlumb_endpoint {
 .label {
     font-size: 11px;
     padding: 4px;
+    margin-left: 7px;
 }
 
 .component {
@@ -800,10 +814,6 @@ div[name="Arguments"] button {
     border-bottom: 5px solid orange !important;
 }
 
-.label {
-    margin-left: 10px;
-}
-
 .release-status {
     font-size: 12px;
 }
@@ -919,6 +929,23 @@ li {
 
 #layout-button {
     font-size: 8px;
+    background-color: white;
+}
+
+#add-bucket-button {
+    font-size: 8px;
+    margin-left: 7px;
+    background-color: white;
+}
+
+#pin-palette-button {
+    padding: 2px 6px;
+    background-color: white;
+}
+
+.dropdown {
+    display: inline-block;
+    padding-bottom: 5px;
 }
 
 #accordion-properties button {
@@ -944,21 +971,31 @@ li.success {
     background-color: #dff0d8 !important;
 }
 
+.sortable-placeholder {
+    opacity: 0.3;
+}
+
 .templates-menu {
     text-align: left;
     margin-left: 10px;
     margin-top: 5px;
 }
 
-.templates-menu > li {
+.templates-menu.locked {
+    max-height: 80vh;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+.templates-menu .templates-menu-locked> li {
     background-color: white !important;
 }
 
-.templates-menu .dropdown-header img {
+.templates-menu .templates-menu-locked .dropdown-header img {
     width: 20px;
 }
 
-.templates-menu .dropdown-header {
+.templates-menu .templates-menu-locked .dropdown-header {
     font-style: italic;
 }
 

--- a/app/styles/studio.css
+++ b/app/styles/studio.css
@@ -92,7 +92,7 @@ footer {
 
 .btn-group {
     width: max-content;
-    height: max-content;
+    height: 26px;
     display: inline-flex;
     margin-top: -2px;
 }


### PR DESCRIPTION
In this PR:
- Add pin functionality to pin/unpin the palette(sticky/relative position).
- Add button to add buckets to the palette easily
- Reconstruct the tools panel into a 3 div column design instead of cell design
- New buckets are added in a new line if width is insufficient
- fix old bugs like dragging an element under the left panel
- improve the layout for multiple things