### PR TITLE
fix [PA:CREDENTIAL]: disable validity check during creating wf

### DIFF
--- a/app/scripts/proactive/model/Job.js
+++ b/app/scripts/proactive/model/Job.js
@@ -260,7 +260,7 @@ define(
         var that = this;
         this.schema.Variables.subSchema.Model.validators = [
           function checkVariableValue(value, formValues) {
-            if (formValues.Model.length > 0) {
+            if (formValues.Model.length > 0 && formValues.Model.toLowerCase() != "pa:credential") {
               if (StudioApp.isWorkflowOpen()) {
                 that.updateVariable(formValues);
                 var validationData = StudioClient.validate(StudioApp.views.xmlView.generateXml(), StudioApp.models.jobModel);

--- a/app/scripts/proactive/model/Job.js
+++ b/app/scripts/proactive/model/Job.js
@@ -260,10 +260,10 @@ define(
         var that = this;
         this.schema.Variables.subSchema.Model.validators = [
           function checkVariableValue(value, formValues) {
-            if (formValues.Model.length > 0 && formValues.Model.toLowerCase() != "pa:credential") {
+            if (formValues.Model.length > 0) {
               if (StudioApp.isWorkflowOpen()) {
                 that.updateVariable(formValues);
-                var validationData = StudioClient.validate(StudioApp.views.xmlView.generateXml(), StudioApp.models.jobModel);
+                var validationData = StudioClient.validate(StudioApp.views.xmlView.generateXml(), StudioApp.models.jobModel, false);
                 if (!validationData.valid) {
                   var err = {
                     type: 'Validation',

--- a/app/scripts/proactive/model/Task.js
+++ b/app/scripts/proactive/model/Task.js
@@ -446,11 +446,11 @@ define(
                 var that = this;
                 this.schema.Variables.subSchema.Model.validators = [
                     function checkVariableValue(value, formValues) {
-                        if (formValues.Model.length > 0 && formValues.Model.toLowerCase() != "pa:credential") {
+                        if (formValues.Model.length > 0) {
                             var StudioApp = require('StudioApp');
                             if (StudioApp.isWorkflowOpen()) {
                                 that.updateVariable(formValues);
-                                var validationData = StudioClient.validate(StudioApp.views.xmlView.generateXml(), StudioApp.models.jobModel);
+                                var validationData = StudioClient.validate(StudioApp.views.xmlView.generateXml(), StudioApp.models.jobModel, false);
                                 if (!validationData.valid) {
                                     var err = {
                                         type: 'Validation',

--- a/app/scripts/proactive/model/Task.js
+++ b/app/scripts/proactive/model/Task.js
@@ -446,7 +446,7 @@ define(
                 var that = this;
                 this.schema.Variables.subSchema.Model.validators = [
                     function checkVariableValue(value, formValues) {
-                        if (formValues.Model.length > 0) {
+                        if (formValues.Model.length > 0 && formValues.Model.toLowerCase() != "pa:credential") {
                             var StudioApp = require('StudioApp');
                             if (StudioApp.isWorkflowOpen()) {
                                 that.updateVariable(formValues);

--- a/app/scripts/proactive/rest/studio-client.js
+++ b/app/scripts/proactive/rest/studio-client.js
@@ -282,12 +282,13 @@ define(
                     if ((jobModel.getTasksCount() == 0)) {
                         return false;
                     }
-
                 }
+
                 var that = this;
-                return Boolean([that.send_multipart_request(config.restApiUrl + "/validate", jobXml, {
-                    "sessionid": localStorage['pa.session']
-                }, function(result) {
+                // during automaticValidation, not pass sessionId to disable checking the validity of PA:CREDENTIALS variables default value
+                var headers = automaticValidation ? {} : {"sessionid": localStorage['pa.session']};
+
+                return Boolean([that.send_multipart_request(config.restApiUrl + "/validate", jobXml, headers, function(result) {
 
                     if (that.lastResult) {
 
@@ -316,13 +317,13 @@ define(
                     that.lastResult = result;
                 }, true)]);
             },
-            validate: function(jobXml, jobModel) {
+            validate: function(jobXml, jobModel, checkCredential) {
                 if (!localStorage['pa.session']) return;
 
                 var that = this;
-                return that.send_multipart_request(config.restApiUrl + "/validate", jobXml, {
-                    "sessionid": localStorage['pa.session']
-                }, null, false);
+                // only pass sessionId when want to check the validity of PA:CREDENTIALS variables
+                var headers = checkCredential ? {"sessionid": localStorage['pa.session']} : {};
+                return that.send_multipart_request(config.restApiUrl + "/validate", jobXml, headers, null, false);
             },
             resetLastValidationResult: function() {
                 this.lastResult = undefined;

--- a/app/scripts/proactive/view/dom.js
+++ b/app/scripts/proactive/view/dom.js
@@ -548,7 +548,7 @@ define(
         function validate() {
             var studioApp = require('StudioApp');
             var xml = studioApp.views.xmlView.generateXml();
-            return StudioClient.validate(xml, studioApp.models.jobModel);
+            return StudioClient.validate(xml, studioApp.models.jobModel, true);
         }
 
         $("#clear-button, #clear-button-tool").click(function (event) {


### PR DESCRIPTION
When the workflow designer create a workflow variable of the type `PA:CREDENTIAL`, its default value should not be checked whether exists in the third-party credentials.

Therefore, when sending validation request in case of variable creation and automatic validation (i.e., checking default value cases), the validation request should not contain sessionid.