### PR TITLE
Fix third-party-credentials management modal

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -720,6 +720,10 @@
     </div>
 </div>
 
+<!--style="overflow:hidden; outline:none"-->
+<div id="third-party-credential-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+</div>
+
 <div id="plan-workflow-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content" style="min-width: 900px;">

--- a/app/index.html
+++ b/app/index.html
@@ -703,8 +703,8 @@
 </div>
 
 <div id="execute-workflow-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content" style="min-width: 900px;">
+    <div class="modal-dialog" style="min-width: 900px;">
+        <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
                 <h3>Execute your workflow as a job</h3>

--- a/app/scripts/proactive/templates/job-variable-template.html
+++ b/app/scripts/proactive/templates/job-variable-template.html
@@ -136,6 +136,3 @@
 </ul>
 <label style="color:red;text-align:center;width:100%"><%- errorMessage %></label>
 <label style="color:green;text-align:center;width:100%"><%- infoMessage %></label>
-
-<div id="third-party-credential-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true" style="overflow:hidden; outline:none">
-</div>

--- a/app/scripts/proactive/templates/third-party-credential-template.html
+++ b/app/scripts/proactive/templates/third-party-credential-template.html
@@ -4,7 +4,7 @@
             <button type="button" class="close third-party-credential-close" aria-hidden="true">×</button>
             <h3>Third-Party Credentials</h3>
         </div>
-        <div id="third-party-credential-body" class="modal-body" style="height: 250px;">
+        <div id="third-party-credential-body" class="modal-body">
             <div id="third-party-credential-container" style="overflow-y: scroll; height: 160px;">
                 <table id="third-party-credential-table" class="table">
                     <thead>

--- a/app/scripts/proactive/view/JobVariableView.js
+++ b/app/scripts/proactive/view/JobVariableView.js
@@ -22,7 +22,6 @@ define(
             this.$el = $('#job-variables');
             // fix overlays of nested modal "third-party-credential-modal" inside "execute-workflow-modal" (backdrop overlays the previous modal)
             $(document).on('show.bs.modal', '.modal', function () {
-                console.log("show.bs.modal")
                 var zIndex = 1040 + (10 * $('.modal:visible').length);
                 $(this).css('z-index', zIndex);
                 // setTimeout is used because the .modal-backdrop isn't created when the event show.bs.modal is triggered.

--- a/app/scripts/proactive/view/JobVariableView.js
+++ b/app/scripts/proactive/view/JobVariableView.js
@@ -20,6 +20,16 @@ define(
 
         initialize: function () {
             this.$el = $('#job-variables');
+            // fix overlays of nested modal "third-party-credential-modal" inside "execute-workflow-modal" (backdrop overlays the previous modal)
+            $(document).on('show.bs.modal', '.modal', function () {
+                console.log("show.bs.modal")
+                var zIndex = 1040 + (10 * $('.modal:visible').length);
+                $(this).css('z-index', zIndex);
+                // setTimeout is used because the .modal-backdrop isn't created when the event show.bs.modal is triggered.
+                setTimeout(function() {
+                    $('.modal-backdrop').not('.modal-stack').css('z-index', zIndex - 1).addClass('modal-stack');
+                }, 0);
+            });
         },
 
         render: function (jobInfos) {


### PR DESCRIPTION
Improve the UI of third-party-credentials management modal:
- grey out the underlying modal (its parent modal: execute-workflow-modal)
- centralize horizontally its parent modal execute-workflow-modal