### PR TITLE
fix gray layout when import selection script from catalog

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -702,7 +702,7 @@
     </div>
 </div>
 
-<div id="execute-workflow-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+<div id="execute-workflow-modal" class="modal fade nested-modal" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog" style="min-width: 900px;">
         <div class="modal-content">
             <div class="modal-header">
@@ -721,7 +721,7 @@
 </div>
 
 <!--style="overflow:hidden; outline:none"-->
-<div id="third-party-credential-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+<div id="third-party-credential-modal" class="modal fade nested-modal" tabindex="-1" role="dialog" aria-hidden="true">
 </div>
 
 <div id="plan-workflow-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">

--- a/app/scripts/proactive/view/JobVariableView.js
+++ b/app/scripts/proactive/view/JobVariableView.js
@@ -21,7 +21,7 @@ define(
         initialize: function () {
             this.$el = $('#job-variables');
             // fix overlays of nested modal "third-party-credential-modal" inside "execute-workflow-modal" (backdrop overlays the previous modal)
-            $(document).on('show.bs.modal', '.modal', function () {
+            $(document).on('show.bs.modal', '.nested-modal', function() {
                 var zIndex = 1040 + (10 * $('.modal:visible').length);
                 $(this).css('z-index', zIndex);
                 // setTimeout is used because the .modal-backdrop isn't created when the event show.bs.modal is triggered.


### PR DESCRIPTION
zIndex modification should only apply to the 3rd-party-cred modal to avoid impact catalog script import