### PR TITLE
Improve docker fork environment template

### DIFF
--- a/app/scripts/proactive/config.js
+++ b/app/scripts/proactive/config.js
@@ -178,40 +178,88 @@ define(function () {
         docker_env_script: `
 // This script creates a docker fork environment using java as docker image
 
-// In the Java Home location field, use the value: "/usr" to force using the JRE provided in the docker image below (Recommended).
-// Be aware, that the prefix command is internally split by spaces. So paths with spaces won't work.
+// If used on windows:
+//  - currently, only linux containers are supported
+//  - make sure the drives containing the scheduler installation and TEMP folders are shared with docker containers
+//  - the container used must have java installed by default in the /usr folder. Change the value of the java home parameter to use a different installation path
+// On linux, the java installation used by the ProActive Node will be also used inside the container
+
 // Prepare Docker parameters
+import org.ow2.proactive.utils.OperatingSystem;
+import org.ow2.proactive.utils.OperatingSystemFamily;
+
 containerName = "java"
-dockerRunCommand =  "docker run "
-dockerParameters = "--rm --env HOME=/tmp "
+cmd = []
+cmd.add("docker")
+cmd.add("run")
+cmd.add("--rm")
+cmd.add("--env")
+cmd.add("HOME=/tmp")
+
+String osName = System.getProperty("os.name");
+println "Operating system : " + osName;
+OperatingSystem operatingSystem = OperatingSystem.resolveOrError(osName);
+OperatingSystemFamily family = operatingSystem.getFamily();
+
+switch (family) {
+    case OperatingSystemFamily.WINDOWS:
+    	isWindows = true;
+    	break;
+    default:
+        isWindows = false;
+}
+forkEnvironment.setDockerWindowsToLinux(isWindows)
+
 // Prepare ProActive home volume
 paHomeHost = variables.get("PA_SCHEDULER_HOME")
-paHomeContainer = variables.get("PA_SCHEDULER_HOME")
-proActiveHomeVolume = "-v " + paHomeHost + ":" + paHomeContainer + " "
+paHomeContainer = (isWindows ? forkEnvironment.convertToLinuxPath(variables.get("PA_SCHEDULER_HOME")) : variables.get("PA_SCHEDULER_HOME"))
+cmd.add("-v")
+cmd.add(paHomeHost + ":" + paHomeContainer)
 // Prepare working directory (For Dataspaces and serialized task file)
 workspaceHost = localspace
-workspaceContainer = localspace
-workspaceVolume = "-v " + workspaceHost + ":" + workspaceContainer + " "
-// Prepare container working directory
-containerWorkingDirectory = "-w " + workspaceContainer + " "
+workspaceContainer = (isWindows ? forkEnvironment.convertToLinuxPath(workspaceHost) : workspaceHost)
+cmd.add("-v")
+cmd.add(workspaceHost + ":" + workspaceContainer)
 
-sigar = new org.hyperic.sigar.Sigar()
-try {
-    pid = sigar.getPid()
-    creds = sigar.getProcCred(pid)
-    uid = creds.getUid()
-    gid = creds.getGid()
-    userDefinition = "--user=" + uid + ":" + gid + " "
-} catch (Exception e) {
-    println "Cannot retrieve user or group id : " + e.getMessage()
-    userDefinition = "";
-} finally {
-    sigar.close()
+cachespaceHost = cachespace
+cachespaceContainer = (isWindows ? forkEnvironment.convertToLinuxPath(cachespaceHost) : cachespaceHost)
+cmd.add("-v")
+cmd.add(cachespaceHost + ":" + cachespaceContainer)
+
+if (!isWindows) {
+     // when not on windows, mount and use the current JRE
+    currentJavaHome = System.getProperty("java.home")
+	forkEnvironment.setJavaHome(currentJavaHome)
+    cmd.add("-v")
+    cmd.add(currentJavaHome + ":" + currentJavaHome)
 }
 
-// Save pre execution command into magic variable 'preJavaHomeCmd', which is picked up by the node
-preJavaHomeCmd = dockerRunCommand + dockerParameters + proActiveHomeVolume + workspaceVolume + userDefinition + containerWorkingDirectory + containerName
-println "DOCKER_FULL_CMD:    " + preJavaHomeCmd
+// Prepare container working directory
+cmd.add("-w")
+cmd.add(workspaceContainer)
+
+if (isWindows) {
+    // linux on windows does not allow sharing identities (such as AD identities)
+} else {
+    sigar = new org.hyperic.sigar.Sigar()
+    try {
+        pid = sigar.getPid()
+        creds = sigar.getProcCred(pid)
+        uid = creds.getUid()
+        gid = creds.getGid()
+        cmd.add("--user=" + uid + ":" + gid)
+    } catch (Exception e) {
+        println "Cannot retrieve user or group id : " + e.getMessage()
+    } finally {
+        sigar.close()
+    }
+}
+cmd.add(containerName)
+
+forkEnvironment.setPreJavaCommand(cmd)
+
+// Show the generated command
+println "DOCKER COMMAND : " + forkEnvironment.getPreJavaCommand()
         `
     };
 });


### PR DESCRIPTION
 - make it cross-platform (windows or linux)
 - use new java pre command format (more robust, tolerate paths with spaces)
 - use current java installation by default (allows using generic containers without java)
 - mount cache space