### PR TITLE
Fix and improve third-party credentials management

### DIFF
--- a/app/scripts/proactive/rest/studio-client.js
+++ b/app/scripts/proactive/rest/studio-client.js
@@ -275,7 +275,7 @@ define(
 
             },
 
-            validateWithPopup: function(jobXml, jobModel, automaticValidation) {
+            validateWithPopup: function(jobXml, jobModel, automaticValidation, disableCheckCredential) {
                 if (!localStorage['pa.session']) return false;
 
                 if (automaticValidation) {
@@ -285,8 +285,8 @@ define(
                 }
 
                 var that = this;
-                // during automaticValidation, not pass sessionId to disable checking the validity of PA:CREDENTIALS variables default value
-                var headers = automaticValidation ? {} : {"sessionid": localStorage['pa.session']};
+                // not pass sessionId to disable checking the validity of PA:CREDENTIALS variables default value
+                var headers = disableCheckCredential ? {} : {"sessionid": localStorage['pa.session']};
 
                 return Boolean([that.send_multipart_request(config.restApiUrl + "/validate", jobXml, headers, function(result) {
 

--- a/app/scripts/proactive/templates/third-party-credential-template.html
+++ b/app/scripts/proactive/templates/third-party-credential-template.html
@@ -5,24 +5,21 @@
             <h3>Third-Party Credentials</h3>
         </div>
         <div id="third-party-credential-body" class="modal-body">
-            <div id="third-party-credential-container" style="overflow-y: scroll; height: 160px;">
+            <div id="third-party-credential-container" style="overflow-x: hidden; overflow-y: scroll; height: 270px;">
                 <table id="third-party-credential-table" class="table">
                     <thead>
                     <tr>
-                        <th>Key</th>
-                        <th>Credential</th>
-                        <th></th>
+                        <th width="40%">Key</th>
+                        <th width="40%">Credential</th>
+                        <th width="20%"></th>
                     </tr>
                     </thead>
                     <tbody>
                     <% for (var index in credentialKeys) { %>
                     <tr>
-                        <td><%- credentialKeys[index] %></td>
+                        <td style="word-break: break-all;"><%- credentialKeys[index] %></td>
                         <td>******</td>
-                        <td>
-                            <button id="<%- credentialKeys[index] %>" class="btn remove-third-party-credential fas fa-trash-alt" style="background-color:Transparent">
-                            </button>
-                        </td>
+                        <td><button id="<%- credentialKeys[index] %>" class="remove-third-party-credential btn btn-danger fas fa-trash-alt"></button></td>
                     </tr>
                     <% } %>
                     </tbody>
@@ -30,26 +27,22 @@
             </div>
             <br>
             <div id="add-third-party-credential-container">
-                <form id="add-third-party-credential">
-                    <table>
-                        <tr>
-                            <td><label for="new-cred-key">Key:</label></td>
-                            <td><label for="new-cred-value">Credential:</label></td>
-                        </tr>
-                        <tr>
-                            <td><input class="textareavalues" name="Key:" type="text" id="new-cred-key"/></td>
-                            <td><input class="textareavalues" name="Value:" type="password" id="new-cred-value"
-                                       autocomplete="new-password"/></td>
-                            <td>
-                                <button id="add-third-party-credential-button" class="btn" type="button"> Add</button>
-                            </td>
-                        </tr>
-                    </table>
-                </form>
+                <table id="add-3rd-party-cred-table">
+                    <tr>
+                        <td width="40%"><label for="new-cred-key">Key:</label></td>
+                        <td width="40%"><label for="new-cred-value">Credential:</label></td>
+                        <td width="20%"></td>
+                    </tr>
+                    <tr>
+                        <td><input class="textareavalues form-control" type="text" id="new-cred-key"/></td>
+                        <td><input class="textareavalues form-control" type="password" id="new-cred-value" autocomplete="not-a-password"/></td>
+                        <td><button id="add-third-party-credential-button" class="btn btn-success" type="button"> Add </button></td>
+                    </tr>
+                </table>
             </div>
         </div>
         <div class="modal-footer">
-            <button class="btn btn-white third-party-credential-close" type="button"> Close</button>
+            <button class="btn btn-white third-party-credential-close" type="button"> Close </button>
         </div>
     </div>
 </div>

--- a/app/scripts/proactive/templates/third-party-credential-template.html
+++ b/app/scripts/proactive/templates/third-party-credential-template.html
@@ -35,7 +35,7 @@
                     </tr>
                     <tr>
                         <td><input class="textareavalues form-control" type="text" id="new-cred-key"/></td>
-                        <td><input class="textareavalues form-control" type="password" id="new-cred-value" autocomplete="not-a-password"/></td>
+                        <td><input class="textareavalues form-control" type="password" id="new-cred-value" autocomplete="new-password"/></td>
                         <td><button id="add-third-party-credential-button" class="btn btn-success" type="button"> Add </button></td>
                     </tr>
                 </table>

--- a/app/scripts/proactive/view/ThirdPartyCredentialView.js
+++ b/app/scripts/proactive/view/ThirdPartyCredentialView.js
@@ -63,7 +63,7 @@ define(
         thirdPartyCredentialRequest: function(credentialKey, typeRequest, requestData) {
             var that = this;
             $.ajax({
-                url: "/rest/scheduler/credentials/" + credentialKey,
+                url: "/rest/scheduler/credentials/" + encodeURIComponent(credentialKey),
                 type: typeRequest,
                 data: requestData,
                 headers: { "sessionid": localStorage['pa.session'] },

--- a/app/scripts/proactive/view/dom.js
+++ b/app/scripts/proactive/view/dom.js
@@ -165,7 +165,7 @@ define(
                     if (evt.target.readyState == FileReader.DONE) {
                         var json = xml2json.xmlToJson(xml2json.parseXml(evt.target.result));
                         StudioClient.resetLastValidationResult();
-                        if(!StudioClient.validateWithPopup(evt.target.result, json, false)){
+                        if(!StudioClient.validateWithPopup(evt.target.result, json, false, true)){
                            return;
                         }
                         studioApp.merge(json, null);
@@ -771,7 +771,9 @@ define(
             $(".invalid-task").removeClass("invalid-task");
             var studioApp = require('StudioApp');
             if (studioApp.isWorkflowOpen()) {
-                StudioClient.validateWithPopup(studioApp.views.xmlView.generateXml(), studioApp.models.jobModel, automaticValidation);
+                // disable checking the validity of PA:CREDENTIALS variables in case of automaticValidation, to facilitate workflow designer
+                var disableCheckCredential = automaticValidation;
+                StudioClient.validateWithPopup(studioApp.views.xmlView.generateXml(), studioApp.models.jobModel, automaticValidation, disableCheckCredential);
             }
         }
 

--- a/app/styles/studio.css
+++ b/app/styles/studio.css
@@ -1634,6 +1634,11 @@ li.success {
     max-width:200px;
 }
 
+#add-3rd-party-cred-table td {
+    padding-left:10px;
+    padding-right:10px;
+}
+
 /* Remove default bullets */
 ul, #submitFormUL {
   list-style-type: none;


### PR DESCRIPTION
- Fix escape 3rd-party-creds key for path param in the creds add/remove request.(fixed with `encodeURIComponent`)
- Fix: when import/add the workflow from xml file, we should disable check the validity of PA:CREDENTIAL variables.
- Improve: beautify 3rd-party-cred modal in studio (ref BeautifiedModalAdapter) and improve ui when key is too long
  - change add/remove button color
  - align key/creds between creds table and add-cred div
  - break long key to multiple lines.