### PR TITLE
Add automatic encryption for PA:HIDDEN variables

### DIFF
--- a/app/libs/backbone-forms/distribution.amd/backbone-forms.js
+++ b/app/libs/backbone-forms/distribution.amd/backbone-forms.js
@@ -1129,12 +1129,13 @@ Form.Editor = Form.editors.Base = Backbone.View.extend({
         value = this.getValue(),
         formValues = this.form ? this.form.getValue() : {},
         validators = this.validators,
-        getValidator = this.getValidator;
+        getValidator = this.getValidator,
+        form = this.form;
 
     if (validators) {
       //Run through validators until an error is found
       _.every(validators, function(validator) {
-        error = getValidator(validator)(value, formValues);
+        error = getValidator(validator)(value, formValues, form);
 
         return error ? false : true;
       });

--- a/app/libs/backbone-forms/distribution/backbone-forms.js
+++ b/app/libs/backbone-forms/distribution/backbone-forms.js
@@ -1141,12 +1141,13 @@ Form.Editor = Form.editors.Base = Backbone.View.extend({
         value = this.getValue(),
         formValues = this.form ? this.form.getValue() : {},
         validators = this.validators,
-        getValidator = this.getValidator;
+        getValidator = this.getValidator,
+        form = this.form;
 
     if (validators) {
       //Run through validators until an error is found
       _.every(validators, function(validator) {
-        error = getValidator(validator)(value, formValues);
+        error = getValidator(validator)(value, formValues, form);
 
         return error ? false : true;
       });

--- a/app/scripts/proactive/model/Job.js
+++ b/app/scripts/proactive/model/Job.js
@@ -259,7 +259,7 @@ define(
 
         var that = this;
         this.schema.Variables.subSchema.Model.validators = [
-          function checkVariableValue(value, formValues) {
+          function checkVariableValue(value, formValues, form) {
             if (formValues.Model.length > 0) {
               if (StudioApp.isWorkflowOpen()) {
                 that.updateVariable(formValues);
@@ -270,9 +270,13 @@ define(
                     message: "<br><br>" + validationData.errorMessage
                   };
                   return err;
-                } else {
-                    delete that.attributes.BackupVariables;
+                } else if (formValues.Model === "PA:HIDDEN" && formValues.Value.trim().length > 0) {
+                    formValues.Value = validationData.updatedVariables[formValues.Name];
+                    if (form) {
+                        form.setValue(formValues);
+                    }
                 }
+                delete that.attributes.BackupVariables;
               }
             }
           }

--- a/app/scripts/proactive/model/Task.js
+++ b/app/scripts/proactive/model/Task.js
@@ -445,7 +445,7 @@ define(
                 });
                 var that = this;
                 this.schema.Variables.subSchema.Model.validators = [
-                    function checkVariableValue(value, formValues) {
+                    function checkVariableValue(value, formValues, form) {
                         if (formValues.Model.length > 0) {
                             var StudioApp = require('StudioApp');
                             if (StudioApp.isWorkflowOpen()) {
@@ -457,9 +457,13 @@ define(
                                         message: "<br><br>" + validationData.errorMessage
                                     };
                                     return err;
-                                } else {
-                                    delete that.attributes.BackupVariables;
+                                } else if (formValues.Model === "PA:HIDDEN" && formValues.Value.trim().length > 0) {
+                                    formValues.Value = validationData.updatedVariables[that.attributes["Task Name"] + ":" + formValues.Name];
+                                    if (form) {
+                                        form.setValue(formValues);
+                                    }
                                 }
+                                delete that.attributes.BackupVariables;
                             }
                         }
                     }


### PR DESCRIPTION
 - When creating or editing a PA:HIDDEN variable in the workflow, the server response contains the data in encrypted format. Use this value to store it in the workflow instead of clear text data.
 - like often, backbone-forms did not provide the necessary feature, so I resolved on modifying backbone-forms to give access to the current form when validating a list entry. This allows the validation to modify the value when the form is submitted.