### PR TITLE
fix issue #675 for updating if branch

### DIFF
--- a/app/scripts/proactive/model/Task.js
+++ b/app/scripts/proactive/model/Task.js
@@ -632,16 +632,6 @@ define(
                 }
             },
             setControlFlow: function (controlFlowType, task) {
-                if (controlFlowType == 'if') {
-                    if (this.controlFlow['if'] && this.controlFlow['if'].task) {
-                        if (this.controlFlow['if']['else']) {
-                            controlFlowType = 'continuation';
-                        } else {
-                            controlFlowType = 'else';
-                        }
-                    }
-                }
-
                 if (this['set' + controlFlowType]) this['set' + controlFlowType](task);
             },
             removeControlFlow: function (controlFlowType, task) {
@@ -654,10 +644,9 @@ define(
                 this.set({'Control Flow': 'if'});
                 if (!this.controlFlow['if']) {
                     this.controlFlow = {'if': {}}
+                    this.controlFlow['if'].model = new FlowScript();
                 }
-
                 this.controlFlow['if'].task = task;
-                this.controlFlow['if'].model = new FlowScript();
             },
             setelse: function (task) {
                 if (!task) {

--- a/app/scripts/proactive/view/WorkflowView.js
+++ b/app/scripts/proactive/view/WorkflowView.js
@@ -127,7 +127,12 @@ define(
                     if (connection.connection.scope == 'dependency') {
                         targetModel.addDependency(sourceModel);
                     } else {
-                        sourceModel.setControlFlow(connection.connection.scope, targetModel);
+                        var updatedControlFlowType = connection.connection.scope;
+                        if (updatedControlFlowType === "if") {
+                            // when the control flow "if" is updated, we need to get which connection ("if", "else", or "continuation") is updated
+                            updatedControlFlowType = connection.connection.getOverlays().find(element => element.type === "Label").label;
+                        }
+                        sourceModel.setControlFlow(updatedControlFlowType, targetModel);
                     }
                 }
             });


### PR DESCRIPTION
When changed if/else branch connected target task in studio, controlFlow target (if/else/continuation) should be correctly updated in the workflow definition. 

Previously, it always change the "continuation" target to the new associated task, even when it's actually "if" or "else" connection updated in front-end. So it caused inconsistency between workflow diagram and its model definition.

Fix:
- retrieve the updated branch from the connection label, then call the corresponding setif/setelse/setcontinuation function to update task model.
- setif should only initialize the script model to `new FlowScript()` when the control flow "if" is newly set, so that updating if branch target won't erase existing controlFlow script.