### PR TITLE
Fix if

### DIFF
--- a/app/scripts/proactive/model/Task.js
+++ b/app/scripts/proactive/model/Task.js
@@ -680,8 +680,7 @@ define(
                 this.set({'Control Flow': 'none'});
                 if (this.controlFlow['if'].task == task) {
                     console.log('Removing IF')
-                    this.controlFlow['if'].model = undefined;
-                    this.controlFlow['if'].task = undefined;
+                    delete this.controlFlow['if'].task;
                 } else if (this.controlFlow['if']['else'] && this.controlFlow['if']['else'].task == task) {
                     console.log('Removing ELSE')
                     delete this.controlFlow['if']['else'];

--- a/app/scripts/proactive/model/Task.js
+++ b/app/scripts/proactive/model/Task.js
@@ -634,6 +634,16 @@ define(
             setControlFlow: function (controlFlowType, task) {
                 if (this['set' + controlFlowType]) this['set' + controlFlowType](task);
             },
+            createif: function (task) {
+                if (!this.controlFlow['if']) {
+                    this.setif(task);
+                } else if (!this.controlFlow['if']['else']) {
+                    this.setelse(task);
+                } else if (!this.controlFlow['if']['continuation']) {
+                    this.setcontinuation(task);
+                }
+                console.log("after createif this.controlFlow['if']", this.controlFlow['if'])
+            },
             removeControlFlow: function (controlFlowType, task) {
                 if (this['remove' + controlFlowType]) this['remove' + controlFlowType](task);
             },

--- a/app/scripts/proactive/model/Task.js
+++ b/app/scripts/proactive/model/Task.js
@@ -642,7 +642,6 @@ define(
                 } else if (!this.controlFlow['if']['continuation']) {
                     this.setcontinuation(task);
                 }
-                console.log("after createif", this.controlFlow['if'])
             },
             removeControlFlow: function (controlFlowType, task) {
                 if (this['remove' + controlFlowType]) this['remove' + controlFlowType](task);
@@ -660,21 +659,18 @@ define(
                     this.controlFlow['if'].model = new FlowScript();
                 }
                 this.controlFlow['if'].task = task;
-                console.log("after setif", this.controlFlow['if'])
             },
             setelse: function (task) {
                 if (!task) {
                     return;
                 }
                 this.controlFlow['if']['else'] = {task: task};
-                console.log("after setelse", this.controlFlow['if'])
             },
             setcontinuation: function (task) {
                 if (!task) {
                     return;
                 }
                 this.controlFlow['if']['continuation'] = {task: task};
-                console.log("after setcontinuation", this.controlFlow['if'])
             },
             removeif: function (task) {
                 this.set({'Control Flow': 'none'});
@@ -695,7 +691,6 @@ define(
                     this.set({'Control Flow': 'none'});
                     delete this.controlFlow['if'];
                 }
-                console.log("after removeif", this.controlFlow['if'])
             },
             setloop: function (task) {
                 console.log('Adding loop')

--- a/app/scripts/proactive/model/Task.js
+++ b/app/scripts/proactive/model/Task.js
@@ -635,14 +635,14 @@ define(
                 if (this['set' + controlFlowType]) this['set' + controlFlowType](task);
             },
             createif: function (task) {
-                if (!this.controlFlow['if']) {
+                if (!this.controlFlow['if'] || !this.controlFlow['if'].task) {
                     this.setif(task);
                 } else if (!this.controlFlow['if']['else']) {
                     this.setelse(task);
                 } else if (!this.controlFlow['if']['continuation']) {
                     this.setcontinuation(task);
                 }
-                console.log("after createif this.controlFlow['if']", this.controlFlow['if'])
+                console.log("after createif", this.controlFlow['if'])
             },
             removeControlFlow: function (controlFlowType, task) {
                 if (this['remove' + controlFlowType]) this['remove' + controlFlowType](task);
@@ -656,19 +656,25 @@ define(
                     this.controlFlow = {'if': {}}
                     this.controlFlow['if'].model = new FlowScript();
                 }
+                if(!this.controlFlow['if'].model) {
+                    this.controlFlow['if'].model = new FlowScript();
+                }
                 this.controlFlow['if'].task = task;
+                console.log("after setif", this.controlFlow['if'])
             },
             setelse: function (task) {
                 if (!task) {
                     return;
                 }
                 this.controlFlow['if']['else'] = {task: task};
+                console.log("after setelse", this.controlFlow['if'])
             },
             setcontinuation: function (task) {
                 if (!task) {
                     return;
                 }
                 this.controlFlow['if']['continuation'] = {task: task};
+                console.log("after setcontinuation", this.controlFlow['if'])
             },
             removeif: function (task) {
                 this.set({'Control Flow': 'none'});
@@ -683,7 +689,14 @@ define(
                     console.log('Removing CONTINUATION')
                     delete this.controlFlow['if']['continuation'];
                 }
-                console.log('Removing if branch', this.controlFlow, task)
+                if (this.controlFlow['if'].task || this.controlFlow['if']['else'] && this.controlFlow['if']['else'].task || this.controlFlow['if']['continuation'] && this.controlFlow['if']['continuation'].task) {
+                    // at least one branch is present
+                } else {
+                    console.log('Removing if branch', this.controlFlow, task)
+                    this.set({'Control Flow': 'none'});
+                    delete this.controlFlow['if'];
+                }
+                console.log("after removeif", this.controlFlow['if'])
             },
             setloop: function (task) {
                 console.log('Adding loop')

--- a/app/scripts/proactive/view/TaskView.js
+++ b/app/scripts/proactive/view/TaskView.js
@@ -355,7 +355,7 @@ define(
                         [ "Label", {
                             label: function () {
                                 var ifModel = that.model.controlFlow['if'];
-                                if (!ifModel || ifModel && !ifModel.model) return 'if'
+                                if (!ifModel || !ifModel.model || !ifModel.task) return 'if'
                                 else if (!ifModel['else']) return 'else'
                                 else if (!ifModel['continuation']) return 'continuation'
                                 else return "";

--- a/app/scripts/proactive/view/TaskView.js
+++ b/app/scripts/proactive/view/TaskView.js
@@ -482,7 +482,6 @@ define(
             jsPlumb.connect({source: sourceEndPoint, target: targetEndPoint, overlays: this.overlays()});
         },
         addIf: function (ifFlow, views) {
-            console.log("addIf")
             var endpointIf = this.addSourceEndPoint('if')
 
             if (ifFlow.task) {

--- a/app/scripts/proactive/view/TaskView.js
+++ b/app/scripts/proactive/view/TaskView.js
@@ -286,8 +286,7 @@ define(
                             var connectionDetached = false;
                             if (endPoint.connections) {
                                 var initialConnections = endPoint.connections;
-                                var j;
-                                for (j = initialConnections.length - 1; j >= 0; j--) {
+                                for (var j = initialConnections.length - 1; j >= 0; j--) {
                                     jsPlumb.detach(initialConnections[j]);
                                     connectionDetached = true;
                                 }

--- a/app/scripts/proactive/view/WorkflowView.js
+++ b/app/scripts/proactive/view/WorkflowView.js
@@ -130,9 +130,15 @@ define(
                         var updatedControlFlowType = connection.connection.scope;
                         if (updatedControlFlowType === "if") {
                             // when the control flow "if" is updated, we need to get which connection ("if", "else", or "continuation") is updated
-                            updatedControlFlowType = connection.connection.getOverlays().find(element => element.type === "Label").label;
+                            var connectionLabel = connection.connection.getOverlays().find(element => element.type === "Label").labelText;
+                            if (connectionLabel != null) {
+                                sourceModel.setControlFlow(connectionLabel, targetModel);
+                            } else {
+                                sourceModel.createif(targetModel);
+                            }
+                        } else {
+                            sourceModel.setControlFlow(updatedControlFlowType, targetModel);
                         }
-                        sourceModel.setControlFlow(updatedControlFlowType, targetModel);
                     }
                 }
             });

--- a/app/scripts/proactive/view/WorkflowView.js
+++ b/app/scripts/proactive/view/WorkflowView.js
@@ -131,7 +131,7 @@ define(
                         if (updatedControlFlowType === "if") {
                             // when the control flow "if" is updated, we need to get which connection ("if", "else", or "continuation") is updated
                             var connectionLabel = connection.connection.getOverlay("ifLabel").canvas.textContent;
-                            console.log("updating the connection ", connectionLabel);
+                            console.debug("updating the connection with label: ", connectionLabel);
                             if (connectionLabel) {
                                 sourceModel.setControlFlow(connectionLabel, targetModel);
                             } else {

--- a/app/scripts/proactive/view/WorkflowView.js
+++ b/app/scripts/proactive/view/WorkflowView.js
@@ -130,8 +130,9 @@ define(
                         var updatedControlFlowType = connection.connection.scope;
                         if (updatedControlFlowType === "if") {
                             // when the control flow "if" is updated, we need to get which connection ("if", "else", or "continuation") is updated
-                            var connectionLabel = connection.connection.getOverlays().find(element => element.type === "Label").labelText;
-                            if (connectionLabel != null) {
+                            var connectionLabel = connection.connection.getOverlay("ifLabel").canvas.textContent;
+                            console.log("updating the connection ", connectionLabel);
+                            if (connectionLabel) {
                                 sourceModel.setControlFlow(connectionLabel, targetModel);
                             } else {
                                 sourceModel.createif(targetModel);


### PR DESCRIPTION
- fix the regression of can't **creating if-else-continuation branches** for the task which is manually specified as if control flow (regression imposed from https://github.com/ow2-proactive/studio/commit/a14e501f15540925ec4b8b53ed2e50bee35cb8f6)
- fix the problem of **losing connection label** when remove then recreate a if/else/continuation branch.
- set task control flow to 'none' when its whole if-else-continuation connections are all removed.
- keeping the if control flow script until the whole if-else-continuation control flow is removed. (Previously it's removed when removing the if branch, it will cause losing control flow script when the if branch is drag to empty space, since it's handled as removing old if branch, then create a new if branch to the auto-generated task.)
- when controlFlowChanged, change connections from back to front to avoid array modify breaking indexes.