### PR TITLE
Job submission check : replace variable value only when it does not reference another variable

### DIFF
--- a/app/scripts/proactive/view/dom.js
+++ b/app/scripts/proactive/view/dom.js
@@ -522,10 +522,22 @@ define(
             if (validationData.hasOwnProperty('updatedVariables')) {
                 var updatedVariables = validationData.updatedVariables;
                 if (updatedVariables != null) {
+                    var extractVariableName = function (key) { return (key.split(":").length == 2 ? key.split(":")[1] : key) };
                     for (var key in inputVariables) {
                         if (inputVariables.hasOwnProperty(key)) {
                             var variable = inputVariables[key];
-                            variable.Value = updatedVariables[key];
+                            var containsPattern = false;
+                            if (variable.Value) {
+                                for (var variablePatternCheck in inputVariables) {
+                                    if (variable.Value.indexOf("$" + extractVariableName(variablePatternCheck)) >= 0 ||
+                                    variable.Value.indexOf("${" + extractVariableName(variablePatternCheck) + "}") >= 0) {
+                                        containsPattern = true;
+                                    }
+                                }
+                            }
+                            if (!containsPattern) {
+                                variable.Value = updatedVariables[key];
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Control if the original variable value does not contain a pattern reference to another variable $some_var.
If it does, then replacing the value can lead to mistakes if the referenced variable is changed by the user again
in the submission form.