### PR TITLE
Support to add multi-lines credential value in 3rd-party-credential modal

### DIFF
--- a/app/scripts/proactive/templates/third-party-credential-template.html
+++ b/app/scripts/proactive/templates/third-party-credential-template.html
@@ -29,13 +29,18 @@
             <div id="add-third-party-credential-container">
                 <table id="add-3rd-party-cred-table">
                     <tr>
-                        <td width="40%"><label for="new-cred-key">Key:</label></td>
+                        <td width="30%"><label for="new-cred-key">Key:</label></td>
                         <td width="40%"><label for="new-cred-value">Credential:</label></td>
-                        <td width="20%"></td>
+                        <td width="27%"></td>
+                        <td width="3%"></td>
                     </tr>
                     <tr>
                         <td><input class="textareavalues form-control" type="text" id="new-cred-key"/></td>
-                        <td><input class="textareavalues form-control" type="password" id="new-cred-value" autocomplete="new-password"/></td>
+                        <td>
+                            <input class="textareavalues form-control" type="password" id="new-cred-value" autocomplete="new-password"/>
+                            <textarea class="textareavalues form-control" id="new-cred-value-multiline" style="display:none;" rows="1"></textarea>
+                        </td>
+                        <td><label for="multiline-cred" style="display:inline;"><input type="checkbox" id="multiline-cred" style="vertical-align:top;" />Multiline credential</label></td>
                         <td><button id="add-third-party-credential-button" class="btn btn-success" type="button"> Add </button></td>
                     </tr>
                 </table>

--- a/app/scripts/proactive/view/ThirdPartyCredentialView.js
+++ b/app/scripts/proactive/view/ThirdPartyCredentialView.js
@@ -16,7 +16,8 @@ define(
         events: {
             'click .third-party-credential-close': 'closeThirdPartyCredential',
             'click #add-third-party-credential-button': 'addThirdPartyCredential',
-            'click .remove-third-party-credential': 'removeThirdPartyCredential'
+            'click .remove-third-party-credential': 'removeThirdPartyCredential',
+            'change #multiline-cred': 'changeMultilineCredential'
         },
 
         initialize: function () {
@@ -55,7 +56,8 @@ define(
         },
 
         addThirdPartyCredential: function(event) {
-            this.thirdPartyCredentialRequest($('#new-cred-key').val(), "POST", { value: $('#new-cred-value').val() });
+            var credValue = $('#multiline-cred').prop('checked') ? $('#new-cred-value-multiline').val() : $('#new-cred-value').val();
+            this.thirdPartyCredentialRequest($('#new-cred-key').val(), "POST", { value: credValue });
         },
 
         removeThirdPartyCredential: function(event) {
@@ -76,6 +78,16 @@ define(
                     alert('Failed to edit the third-party credential.' + xhr.status + ': ' + xhr.statusText);
                 }
             });
+        },
+
+        changeMultilineCredential: function(event) {
+            if (event.target.checked) {
+                $('#new-cred-value').hide();
+                $('#new-cred-value-multiline').show();
+            } else {
+                $('#new-cred-value').show();
+                $('#new-cred-value-multiline').hide();
+            }
         },
 
         closeThirdPartyCredential: function () {


### PR DESCRIPTION
In the modal of managing 3rd-party-credentials when submitting a workflow with PA:CREDENTIAL variables, add a checkbox "Multiline credential" to allow the user to input the multi-lines credential value by switching between the password input (for single line credential) and textarea (for multi-lines credential). 