### PR TITLE
publish workflow: editable kind and correct default kind workflow/psa

### DIFF
--- a/app/scripts/proactive/templates/catalog-publish-description-first.html
+++ b/app/scripts/proactive/templates/catalog-publish-description-first.html
@@ -9,7 +9,7 @@
 		</tr>
 		<tr>
 			<td>Kind:</td>
-			<td><input type="text" id="catalog-publish-kind" value="<%= kind %>" disabled class="disabled-input"></td>
+			<td><input type="text" id="catalog-publish-kind" value="<%= kind %>"></td>
 		</tr>
 		<tr>
 			<td>Project name:</td>

--- a/app/scripts/proactive/view/CatalogPublishView.js
+++ b/app/scripts/proactive/view/CatalogPublishView.js
@@ -148,7 +148,8 @@ define(
                     callback: function (revision) {
                         $('#catalog-publish-description-container').empty();
                         var objectDescription = _.template(publishDescription);
-                        $('#catalog-publish-description-container').append(objectDescription({revision: revision, name: objectName, kind: that.kind, kindLabel: that.kindLabel, projectname: projectName}));
+                        var objectKind = that.isPsaWorkflow(that.kind) ? "workflow/psa" : that.kind;
+                        $('#catalog-publish-description-container').append(objectDescription({revision: revision, name: objectName, kind: objectKind, kindLabel: that.kindLabel, projectname: projectName}));
                     }
                 });
             revisionsModel.fetch();
@@ -156,7 +157,8 @@ define(
         addObjectDescription: function(objectName, projectName) {
             var objectDescription = _.template(publishDescriptionFirst);
             this.$('#catalog-publish-description-container').empty();
-            this.$('#catalog-publish-description-container').append(objectDescription({name: objectName, kind: this.kind, kindLabel: this.kindLabel, projectname: projectName}));
+            var objectKind = this.isPsaWorkflow(this.kind) ? "workflow/psa" : this.kind;
+            this.$('#catalog-publish-description-container').append(objectDescription({name: objectName, kind: objectKind, kindLabel: this.kindLabel, projectname: projectName}));
         },
         disablePublishWhenNoPermission: function(rights, targetDescription) {
             if (['write', 'admin'].indexOf(rights) >= 0) {
@@ -335,6 +337,20 @@ define(
             var studioApp = require('StudioApp');
             studioApp.models.catalogBuckets.setKind(filterKind);
             studioApp.models.catalogBuckets.fetch({reset: true});
+        },
+        isPsaWorkflow : function (kind) {
+            if (kind.toLowerCase().indexOf('workflow') != 0) {
+                return false;
+            }
+            var studioApp = require('StudioApp');
+            var genericInfo = studioApp.models.jobModel.get("Generic Info");
+            if (genericInfo) {
+                var pcaStates = genericInfo.filter(function(item){ return item["Property Name"] === "pca.states";})
+                var pcaServiceId = genericInfo.filter(function(item){ return item["Property Name"] === "pca.service.id";})
+                return pcaStates.length && pcaServiceId.length;
+            } else {
+                return false;
+            }
         },
         filterByObjectsByName : function (event){
             event.preventDefault();


### PR DESCRIPTION
- When publish a workflow, make its kind property editable. 
- When the workflow has the generic info `pca.states` and `pca.service.id` specified, change its default kind value to workflow/psa.